### PR TITLE
Unit test for Collections to StandardCharsets

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "test": "./gradlew jvmTest --quiet",
+    "build": "./gradlew build"
+  }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/CRC32Test.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/CRC32Test.kt
@@ -1,0 +1,32 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CRC32Test {
+
+    @Test
+    fun testUpdate() {
+        val crc32 = CRC32()
+        val data = "Hello, World!".encodeToByteArray()
+        crc32.update(data, 0, data.size)
+        assertEquals(0x1C291CA3, crc32.getValue())
+    }
+
+    @Test
+    fun testGetValue() {
+        val crc32 = CRC32()
+        val data = "Hello, World!".encodeToByteArray()
+        crc32.update(data, 0, data.size)
+        assertEquals(0x1C291CA3, crc32.getValue())
+    }
+
+    @Test
+    fun testReset() {
+        val crc32 = CRC32()
+        val data = "Hello, World!".encodeToByteArray()
+        crc32.update(data, 0, data.size)
+        crc32.reset()
+        assertEquals(0, crc32.getValue())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/CollectionsTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/CollectionsTest.kt
@@ -1,0 +1,38 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CollectionsTest {
+
+    @Test
+    fun testSwap() {
+        val list = mutableListOf(1, 2, 3, 4)
+        Collections.swap(list, 1, 3)
+        assertEquals(listOf(1, 4, 3, 2), list)
+
+        assertFailsWith<IndexOutOfBoundsException> {
+            Collections.swap(list, -1, 2)
+        }
+
+        assertFailsWith<IndexOutOfBoundsException> {
+            Collections.swap(list, 1, 4)
+        }
+    }
+
+    @Test
+    fun testReverseOrder() {
+        val comparator = Collections.reverseOrder<Int>(null)
+        assertEquals(1, comparator.compare(2, 1))
+        assertEquals(-1, comparator.compare(1, 2))
+        assertEquals(0, comparator.compare(2, 2))
+    }
+
+    @Test
+    fun testReverse() {
+        val list = mutableListOf(1, 2, 3, 4)
+        Collections.reverse(list)
+        assertEquals(listOf(4, 3, 2, 1), list)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ComparatorsTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ComparatorsTest.kt
@@ -1,0 +1,15 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComparatorsTest {
+
+    @Test
+    fun testReverseOrder() {
+        val comparator = reverseOrder<Int>()
+        assertEquals(1, comparator.compare(2, 1))
+        assertEquals(-1, comparator.compare(1, 2))
+        assertEquals(0, comparator.compare(2, 2))
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/DoubleExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/DoubleExtTest.kt
@@ -1,0 +1,42 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DoubleExtTest {
+
+    @Test
+    fun testDoubleToRawLongBits() {
+        val value = 123.456
+        val bits = Double.doubleToRawLongBits(value)
+        assertEquals(value.toBits(), bits)
+    }
+
+    @Test
+    fun testDoubleToLongBits() {
+        val value = Double.NaN
+        val bits = Double.doubleToLongBits(value)
+        assertEquals(0x7ff8000000000000L, bits)
+    }
+
+    @Test
+    fun testIsNaN() {
+        assertTrue(Double.isNaN(Double.NaN))
+        assertTrue(!Double.isNaN(123.456))
+    }
+
+    @Test
+    fun testCompare() {
+        assertEquals(0, Double.compare(123.456, 123.456))
+        assertTrue(Double.compare(123.456, 654.321) < 0)
+        assertTrue(Double.compare(654.321, 123.456) > 0)
+    }
+
+    @Test
+    fun testLongBitsToDouble() {
+        val bits = 0x405edd2f1a9fbe77L
+        val value = Double.longBitsToDouble(bits)
+        assertEquals(123.456, value)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FilesTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FilesTest.kt
@@ -1,0 +1,45 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.buffered
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+class FilesTest {
+
+    @Test
+    fun testNewInputStream() {
+        val path: Path = Path("/tmp/testfile.txt")
+        SystemFileSystem.sink(path).buffered().use { it.write("Hello, World!".encodeToByteArray()) }
+
+        val inputStream = Files.newInputStream(path)
+        val content = inputStream.readBytes().decodeToString()
+        assertEquals("Hello, World!", content)
+    }
+
+    @Test
+    fun testNewOutputStream() {
+        val path: Path = Path("/tmp/testfile.txt")
+
+        val outputStream = Files.newOutputStream(path)
+        outputStream.write("Hello, World!".encodeToByteArray())
+        outputStream.close()
+
+        val content = SystemFileSystem.source(path).buffered().use { it.readBytes().decodeToString() }
+        assertEquals("Hello, World!", content)
+    }
+
+    @Test
+    fun testNewBufferedReader() {
+        val path: Path = Path("/tmp/testfile.txt")
+        SystemFileSystem.sink(path).buffered().use { it.write("Hello, World!".encodeToByteArray()) }
+
+        val reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)
+        val content = reader.readText()
+        assertEquals("Hello, World!", content)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FilterInputStreamTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FilterInputStreamTest.kt
@@ -1,0 +1,75 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlinx.io.IOException
+import kotlinx.io.Source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FilterInputStreamTest {
+
+    private fun createTestStream(data: ByteArray): FilterInputStream {
+        val buffer = Buffer().apply { write(data) }
+        val source = object : Source {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                return buffer.read(sink, byteCount)
+            }
+
+            override fun close() {}
+        }
+        return FilterInputStream(KIOSourceInputStream(source))
+    }
+
+    @Test
+    fun testRead() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        for (byte in data) {
+            assertEquals(byte.toInt(), stream.read())
+        }
+        assertEquals(-1, stream.read())
+    }
+
+    @Test
+    fun testSkip() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        assertEquals(2, stream.skip(2))
+        assertEquals(3, stream.read())
+    }
+
+    @Test
+    fun testAvailable() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        assertEquals(5, stream.available())
+        stream.read()
+        assertEquals(4, stream.available())
+    }
+
+    @Test
+    fun testClose() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        stream.close()
+        try {
+            stream.read()
+        } catch (e: IOException) {
+            assertTrue(e.message!!.contains("Stream closed"))
+        }
+    }
+
+    @Test
+    fun testMarkAndReset() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        assertTrue(stream.markSupported())
+        stream.mark(10)
+        assertEquals(1, stream.read())
+        assertEquals(2, stream.read())
+        stream.reset()
+        assertEquals(1, stream.read())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FilterOutputStreamTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FilterOutputStreamTest.kt
@@ -1,0 +1,57 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlinx.io.Sink
+import kotlinx.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FilterOutputStreamTest {
+
+    private fun createTestStream(): FilterOutputStream {
+        val buffer = Buffer()
+        val sink = object : Sink {
+            override fun write(source: Buffer, byteCount: Long) {
+                buffer.write(source, byteCount)
+            }
+
+            override fun flush() {}
+
+            override fun close() {}
+        }
+        return FilterOutputStream(KIOSinkOutputStream(sink))
+    }
+
+    @Test
+    fun testWrite() {
+        val stream = createTestStream()
+        stream.write(1)
+        stream.write(byteArrayOf(2, 3, 4, 5))
+        stream.write(byteArrayOf(6, 7, 8, 9, 10), 2, 3)
+        assertEquals(1, stream.out.buffer[0].toInt())
+        assertEquals(2, stream.out.buffer[1].toInt())
+        assertEquals(3, stream.out.buffer[2].toInt())
+        assertEquals(4, stream.out.buffer[3].toInt())
+        assertEquals(5, stream.out.buffer[4].toInt())
+        assertEquals(8, stream.out.buffer[5].toInt())
+        assertEquals(9, stream.out.buffer[6].toInt())
+        assertEquals(10, stream.out.buffer[7].toInt())
+    }
+
+    @Test
+    fun testFlush() {
+        val stream = createTestStream()
+        stream.write(1)
+        stream.flush()
+        assertEquals(1, stream.out.buffer[0].toInt())
+    }
+
+    @Test
+    fun testClose() {
+        val stream = createTestStream()
+        stream.write(1)
+        stream.close()
+        assertFailsWith<IOException> { stream.write(2) }
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FloatBufferTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FloatBufferTest.kt
@@ -1,0 +1,134 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FloatBufferTest {
+
+    @Test
+    fun testAllocate() {
+        val buffer = FloatBuffer.allocate(10)
+        assertEquals(10, buffer.capacity)
+        assertEquals(0, buffer.position)
+        assertEquals(10, buffer.limit)
+    }
+
+    @Test
+    fun testWrap() {
+        val array = floatArrayOf(1.0f, 2.0f, 3.0f)
+        val buffer = FloatBuffer.wrap(array)
+        assertEquals(3, buffer.capacity)
+        assertEquals(0, buffer.position)
+        assertEquals(3, buffer.limit)
+        assertEquals(1.0f, buffer.get(0))
+        assertEquals(2.0f, buffer.get(1))
+        assertEquals(3.0f, buffer.get(2))
+    }
+
+    @Test
+    fun testRemaining() {
+        val buffer = FloatBuffer.allocate(10)
+        assertEquals(10, buffer.remaining())
+        buffer.position(5)
+        assertEquals(5, buffer.remaining())
+    }
+
+    @Test
+    fun testHasRemaining() {
+        val buffer = FloatBuffer.allocate(10)
+        assertTrue(buffer.hasRemaining())
+        buffer.position(10)
+        assertTrue(!buffer.hasRemaining())
+    }
+
+    @Test
+    fun testClear() {
+        val buffer = FloatBuffer.allocate(10)
+        buffer.position(5)
+        buffer.clear()
+        assertEquals(0, buffer.position)
+        assertEquals(10, buffer.limit)
+    }
+
+    @Test
+    fun testFlip() {
+        val buffer = FloatBuffer.allocate(10)
+        buffer.position(5)
+        buffer.flip()
+        assertEquals(0, buffer.position)
+        assertEquals(5, buffer.limit)
+    }
+
+    @Test
+    fun testDuplicate() {
+        val buffer = FloatBuffer.allocate(10)
+        buffer.position(5)
+        buffer.limit(7)
+        val duplicate = buffer.duplicate()
+        assertEquals(10, duplicate.capacity)
+        assertEquals(5, duplicate.position)
+        assertEquals(7, duplicate.limit)
+    }
+
+    @Test
+    fun testGet() {
+        val array = floatArrayOf(1.0f, 2.0f, 3.0f)
+        val buffer = FloatBuffer.wrap(array)
+        assertEquals(1.0f, buffer.get())
+        assertEquals(2.0f, buffer.get())
+        assertEquals(3.0f, buffer.get())
+    }
+
+    @Test
+    fun testPut() {
+        val buffer = FloatBuffer.allocate(3)
+        buffer.put(1.0f)
+        buffer.put(2.0f)
+        buffer.put(3.0f)
+        assertEquals(1.0f, buffer.get(0))
+        assertEquals(2.0f, buffer.get(1))
+        assertEquals(3.0f, buffer.get(2))
+    }
+
+    @Test
+    fun testSlice() {
+        val array = floatArrayOf(1.0f, 2.0f, 3.0f, 4.0f, 5.0f)
+        val buffer = FloatBuffer.wrap(array)
+        buffer.position(2)
+        val slice = buffer.slice()
+        assertEquals(3, slice.capacity)
+        assertEquals(0, slice.position)
+        assertEquals(3, slice.limit)
+        assertEquals(3.0f, slice.get(0))
+        assertEquals(4.0f, slice.get(1))
+        assertEquals(5.0f, slice.get(2))
+    }
+
+    @Test
+    fun testCompareTo() {
+        val buffer1 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 3.0f))
+        val buffer2 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 3.0f))
+        val buffer3 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 4.0f))
+        assertEquals(0, buffer1.compareTo(buffer2))
+        assertTrue(buffer1.compareTo(buffer3) < 0)
+        assertTrue(buffer3.compareTo(buffer1) > 0)
+    }
+
+    @Test
+    fun testEquals() {
+        val buffer1 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 3.0f))
+        val buffer2 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 3.0f))
+        val buffer3 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 4.0f))
+        assertTrue(buffer1 == buffer2)
+        assertTrue(buffer1 != buffer3)
+    }
+
+    @Test
+    fun testHashCode() {
+        val buffer1 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 3.0f))
+        val buffer2 = FloatBuffer.wrap(floatArrayOf(1.0f, 2.0f, 3.0f))
+        assertEquals(buffer1.hashCode(), buffer2.hashCode())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FloatExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FloatExtTest.kt
@@ -1,0 +1,56 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FloatExtTest {
+
+    @Test
+    fun testCompare() {
+        assertEquals(0, Float.compare(123.456f, 123.456f))
+        assertTrue(Float.compare(123.456f, 654.321f) < 0)
+        assertTrue(Float.compare(654.321f, 123.456f) > 0)
+    }
+
+    @Test
+    fun testIsNaN() {
+        assertTrue(Float.isNaN(Float.NaN))
+        assertTrue(!Float.isNaN(123.456f))
+    }
+
+    @Test
+    fun testIsFinite() {
+        assertTrue(Float.isFinite(123.456f))
+        assertTrue(!Float.isFinite(Float.POSITIVE_INFINITY))
+        assertTrue(!Float.isFinite(Float.NEGATIVE_INFINITY))
+    }
+
+    @Test
+    fun testIsInfinite() {
+        assertTrue(Float.isInfinite(Float.POSITIVE_INFINITY))
+        assertTrue(Float.isInfinite(Float.NEGATIVE_INFINITY))
+        assertTrue(!Float.isInfinite(123.456f))
+    }
+
+    @Test
+    fun testFloatToRawIntBits() {
+        val value = 123.456f
+        val bits = Float.floatToRawIntBits(value)
+        assertEquals(value.toBits(), bits)
+    }
+
+    @Test
+    fun testFloatToIntBits() {
+        val value = Float.NaN
+        val bits = Float.floatToIntBits(value)
+        assertEquals(0x7fc00000, bits)
+    }
+
+    @Test
+    fun testIntBitsToFloat() {
+        val bits = 0x42f6e979
+        val value = Float.intBitsToFloat(bits)
+        assertEquals(123.456f, value)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FutureTaskTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/FutureTaskTest.kt
@@ -1,0 +1,76 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.coroutines.*
+import kotlin.test.*
+
+class FutureTaskTest {
+
+    @Test
+    fun testCancel() = runBlocking {
+        val task = FutureTask(Callable {
+            delay(1000)
+            "result"
+        })
+        task.run()
+        delay(100)
+        assertTrue(task.cancel(true))
+        assertTrue(task.isCancelled())
+        assertTrue(task.isDone())
+    }
+
+    @Test
+    fun testIsDone() = runBlocking {
+        val task = FutureTask(Callable {
+            delay(100)
+            "result"
+        })
+        task.run()
+        assertFalse(task.isDone())
+        delay(200)
+        assertTrue(task.isDone())
+    }
+
+    @Test
+    fun testIsCancelled() = runBlocking {
+        val task = FutureTask(Callable {
+            delay(1000)
+            "result"
+        })
+        task.run()
+        delay(100)
+        task.cancel(true)
+        assertTrue(task.isCancelled())
+    }
+
+    @Test
+    fun testGet() = runBlocking {
+        val task = FutureTask(Callable {
+            delay(100)
+            "result"
+        })
+        task.run()
+        assertEquals("result", task.get())
+    }
+
+    @Test
+    fun testRun() = runBlocking {
+        val task = FutureTask(Callable {
+            "result"
+        })
+        task.run()
+        assertEquals("result", task.get())
+    }
+
+    @Test
+    fun testRunAndReset() = runBlocking {
+        val task = object : FutureTask<String>(Callable {
+            "result"
+        }) {
+            override fun runAndReset(): Boolean {
+                return super.runAndReset()
+            }
+        }
+        assertTrue(task.runAndReset())
+        assertFalse(task.isDone())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/InputStreamReaderTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/InputStreamReaderTest.kt
@@ -1,0 +1,52 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InputStreamReaderTest {
+
+    @Test
+    fun testReadSingleCharacter() {
+        val input = "Hello, World!".encodeToByteArray()
+        val inputStream = KIOSourceInputStream(Buffer().write(input))
+        val reader = InputStreamReader(inputStream, Charset.forName("UTF-8"))
+
+        val firstChar = reader.read()
+        assertEquals('H'.code, firstChar)
+    }
+
+    @Test
+    fun testReadIntoCharArray() {
+        val input = "Hello, World!".encodeToByteArray()
+        val inputStream = KIOSourceInputStream(Buffer().write(input))
+        val reader = InputStreamReader(inputStream, Charset.forName("UTF-8"))
+
+        val buffer = CharArray(5)
+        val bytesRead = reader.read(buffer, 0, buffer.size)
+        assertEquals(5, bytesRead)
+        assertEquals("Hello", buffer.concatToString())
+    }
+
+    @Test
+    fun testReady() {
+        val input = "Hello, World!".encodeToByteArray()
+        val inputStream = KIOSourceInputStream(Buffer().write(input))
+        val reader = InputStreamReader(inputStream, Charset.forName("UTF-8"))
+
+        assertTrue(reader.ready())
+    }
+
+    @Test
+    fun testClose() {
+        val input = "Hello, World!".encodeToByteArray()
+        val inputStream = KIOSourceInputStream(Buffer().write(input))
+        val reader = InputStreamReader(inputStream, Charset.forName("UTF-8"))
+
+        reader.close()
+        assertFalse(reader.ready())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/IntExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/IntExtTest.kt
@@ -1,0 +1,71 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IntExtTest {
+
+    @Test
+    fun testRotateLeft() {
+        val value = 0b0001_0000
+        val rotated = Int.rotateLeft(value, 2)
+        assertEquals(0b0100_0000, rotated)
+    }
+
+    @Test
+    fun testToBinaryString() {
+        val value = 10
+        val binaryString = Int.toBinaryString(value)
+        assertEquals("1010", binaryString)
+    }
+
+    @Test
+    fun testToUnsignedLong() {
+        val value = -1
+        val unsignedLong = Int.toUnsignedLong(value)
+        assertEquals(4294967295L, unsignedLong)
+    }
+
+    @Test
+    fun testNumberOfLeadingZeros() {
+        val value = 0b0000_1000
+        val leadingZeros = Int.numberOfLeadingZeros(value)
+        assertEquals(28, leadingZeros)
+    }
+
+    @Test
+    fun testNumberOfTrailingZeros() {
+        val value = 0b1000_0000
+        val trailingZeros = Int.numberOfTrailingZeros(value)
+        assertEquals(7, trailingZeros)
+    }
+
+    @Test
+    fun testBitCount() {
+        val value = 0b1010_1010
+        val bitCount = Int.bitCount(value)
+        assertEquals(4, bitCount)
+    }
+
+    @Test
+    fun testCompare() {
+        assertEquals(0, Int.compare(10, 10))
+        assertTrue(Int.compare(10, 20) < 0)
+        assertTrue(Int.compare(20, 10) > 0)
+    }
+
+    @Test
+    fun testSignum() {
+        assertEquals(1, Int.signum(10))
+        assertEquals(-1, Int.signum(-10))
+        assertEquals(0, Int.signum(0))
+    }
+
+    @Test
+    fun testReverseBytes() {
+        val value = 0x12345678
+        val reversed = Int.reverseBytes(value)
+        assertEquals(0x78563412, reversed)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSinkOutputStreamTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSinkOutputStreamTest.kt
@@ -1,0 +1,51 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlinx.io.Sink
+import kotlinx.io.buffer
+import kotlinx.io.sink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class KIOSinkOutputStreamTest {
+
+    @Test
+    fun testWriteSingleByte() {
+        val buffer = Buffer()
+        val sink: Sink = buffer.sink()
+        val outputStream = KIOSinkOutputStream(sink)
+
+        outputStream.write(65) // Write ASCII 'A'
+        outputStream.flush()
+
+        assertEquals("A", buffer.readUtf8())
+    }
+
+    @Test
+    fun testWriteMultipleBytes() {
+        val buffer = Buffer()
+        val sink: Sink = buffer.sink()
+        val outputStream = KIOSinkOutputStream(sink)
+
+        val data = "Hello, World!".encodeToByteArray()
+        for (byte in data) {
+            outputStream.write(byte.toInt())
+        }
+        outputStream.flush()
+
+        assertEquals("Hello, World!", buffer.readUtf8())
+    }
+
+    @Test
+    fun testWriteAfterClose() {
+        val buffer = Buffer()
+        val sink: Sink = buffer.sink()
+        val outputStream = KIOSinkOutputStream(sink)
+
+        outputStream.close()
+        assertFailsWith<IllegalStateException> {
+            outputStream.write(65)
+        }
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceBufferedReaderTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceBufferedReaderTest.kt
@@ -1,0 +1,89 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlinx.io.buffer
+import kotlinx.io.sink
+import kotlinx.io.source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KIOSourceBufferedReaderTest {
+
+    @Test
+    fun testRead() {
+        val text = "Hello, World!"
+        val source: Source = Buffer().writeUtf8(text)
+        val reader = KIOSourceBufferedReader(source)
+
+        val result = CharArray(text.length)
+        reader.read(result, 0, text.length)
+
+        assertEquals(text, String(result))
+    }
+
+    @Test
+    fun testReadLine() {
+        val text = "Hello, World!\nThis is a test."
+        val source: Source = Buffer().writeUtf8(text)
+        val reader = KIOSourceBufferedReader(source)
+
+        val line1 = reader.readLine()
+        val line2 = reader.readLine()
+
+        assertEquals("Hello, World!", line1)
+        assertEquals("This is a test.", line2)
+    }
+
+    @Test
+    fun testReady() {
+        val text = "Hello, World!"
+        val source: Source = Buffer().writeUtf8(text)
+        val reader = KIOSourceBufferedReader(source)
+
+        assertTrue(reader.ready())
+        reader.read()
+        assertTrue(reader.ready())
+    }
+
+    @Test
+    fun testMarkAndReset() {
+        val text = "Hello, World!"
+        val source: Source = Buffer().writeUtf8(text)
+        val reader = KIOSourceBufferedReader(source)
+
+        reader.mark(5)
+        val result1 = CharArray(5)
+        reader.read(result1, 0, 5)
+        assertEquals("Hello", String(result1))
+
+        reader.reset()
+        val result2 = CharArray(5)
+        reader.read(result2, 0, 5)
+        assertEquals("Hello", String(result2))
+    }
+
+    @Test
+    fun testSkip() {
+        val text = "Hello, World!"
+        val source: Source = Buffer().writeUtf8(text)
+        val reader = KIOSourceBufferedReader(source)
+
+        reader.skip(7)
+        val result = CharArray(5)
+        reader.read(result, 0, 5)
+        assertEquals("World", String(result))
+    }
+
+    @Test
+    fun testClose() {
+        val text = "Hello, World!"
+        val source: Source = Buffer().writeUtf8(text)
+        val reader = KIOSourceBufferedReader(source)
+
+        reader.close()
+        assertFalse(reader.ready())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceInputStreamTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceInputStreamTest.kt
@@ -1,0 +1,60 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KIOSourceInputStreamTest {
+
+    private fun createTestStream(data: ByteArray): KIOSourceInputStream {
+        val buffer = Buffer().apply { write(data) }
+        val source = object : Source {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                return buffer.read(sink, byteCount)
+            }
+
+            override fun close() {}
+        }
+        return KIOSourceInputStream(source)
+    }
+
+    @Test
+    fun testRead() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        for (byte in data) {
+            assertEquals(byte.toInt(), stream.read())
+        }
+        assertEquals(-1, stream.read())
+    }
+
+    @Test
+    fun testAvailable() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        assertEquals(data.size, stream.available())
+        stream.read()
+        assertEquals(data.size - 1, stream.available())
+    }
+
+    @Test
+    fun testReadByteArray() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        val buffer = ByteArray(5)
+        val bytesRead = stream.read(buffer)
+        assertEquals(5, bytesRead)
+        assertEquals(data.toList(), buffer.toList())
+    }
+
+    @Test
+    fun testReadByteArrayWithOffsetAndLength() {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val stream = createTestStream(data)
+        val buffer = ByteArray(5)
+        val bytesRead = stream.read(buffer, 1, 3)
+        assertEquals(3, bytesRead)
+        assertEquals(listOf(0, 1, 2, 3, 0), buffer.toList())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/LongBufferTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/LongBufferTest.kt
@@ -1,0 +1,133 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LongBufferTest {
+
+    @Test
+    fun testAllocate() {
+        val buffer = LongBuffer.allocate(10)
+        assertEquals(10, buffer.capacity)
+        assertEquals(0, buffer.position)
+        assertEquals(10, buffer.limit)
+    }
+
+    @Test
+    fun testWrap() {
+        val array = longArrayOf(1L, 2L, 3L)
+        val buffer = LongBuffer.wrap(array)
+        assertEquals(3, buffer.capacity)
+        assertEquals(0, buffer.position)
+        assertEquals(3, buffer.limit)
+        assertEquals(1L, buffer.get(0))
+        assertEquals(2L, buffer.get(1))
+        assertEquals(3L, buffer.get(2))
+    }
+
+    @Test
+    fun testRemaining() {
+        val buffer = LongBuffer.allocate(10)
+        assertEquals(10, buffer.remaining())
+        buffer.position(5)
+        assertEquals(5, buffer.remaining())
+    }
+
+    @Test
+    fun testHasRemaining() {
+        val buffer = LongBuffer.allocate(10)
+        assertTrue(buffer.hasRemaining())
+        buffer.position(10)
+        assertTrue(!buffer.hasRemaining())
+    }
+
+    @Test
+    fun testClear() {
+        val buffer = LongBuffer.allocate(10)
+        buffer.position(5)
+        buffer.clear()
+        assertEquals(0, buffer.position)
+        assertEquals(10, buffer.limit)
+    }
+
+    @Test
+    fun testFlip() {
+        val buffer = LongBuffer.allocate(10)
+        buffer.position(5)
+        buffer.flip()
+        assertEquals(0, buffer.position)
+        assertEquals(5, buffer.limit)
+    }
+
+    @Test
+    fun testDuplicate() {
+        val buffer = LongBuffer.allocate(10)
+        buffer.position(5)
+        buffer.limit(7)
+        val duplicate = buffer.duplicate()
+        assertEquals(10, duplicate.capacity)
+        assertEquals(5, duplicate.position)
+        assertEquals(7, duplicate.limit)
+    }
+
+    @Test
+    fun testGet() {
+        val array = longArrayOf(1L, 2L, 3L)
+        val buffer = LongBuffer.wrap(array)
+        assertEquals(1L, buffer.get())
+        assertEquals(2L, buffer.get())
+        assertEquals(3L, buffer.get())
+    }
+
+    @Test
+    fun testPut() {
+        val buffer = LongBuffer.allocate(3)
+        buffer.put(1L)
+        buffer.put(2L)
+        buffer.put(3L)
+        assertEquals(1L, buffer.get(0))
+        assertEquals(2L, buffer.get(1))
+        assertEquals(3L, buffer.get(2))
+    }
+
+    @Test
+    fun testSlice() {
+        val array = longArrayOf(1L, 2L, 3L, 4L, 5L)
+        val buffer = LongBuffer.wrap(array)
+        buffer.position(2)
+        val slice = buffer.slice()
+        assertEquals(3, slice.capacity)
+        assertEquals(0, slice.position)
+        assertEquals(3, slice.limit)
+        assertEquals(3L, slice.get(0))
+        assertEquals(4L, slice.get(1))
+        assertEquals(5L, slice.get(2))
+    }
+
+    @Test
+    fun testCompareTo() {
+        val buffer1 = LongBuffer.wrap(longArrayOf(1L, 2L, 3L))
+        val buffer2 = LongBuffer.wrap(longArrayOf(1L, 2L, 3L))
+        val buffer3 = LongBuffer.wrap(longArrayOf(1L, 2L, 4L))
+        assertEquals(0, buffer1.compareTo(buffer2))
+        assertTrue(buffer1.compareTo(buffer3) < 0)
+        assertTrue(buffer3.compareTo(buffer1) > 0)
+    }
+
+    @Test
+    fun testEquals() {
+        val buffer1 = LongBuffer.wrap(longArrayOf(1L, 2L, 3L))
+        val buffer2 = LongBuffer.wrap(longArrayOf(1L, 2L, 3L))
+        val buffer3 = LongBuffer.wrap(longArrayOf(1L, 2L, 4L))
+        assertTrue(buffer1 == buffer2)
+        assertTrue(buffer1 != buffer3)
+    }
+
+    @Test
+    fun testHashCode() {
+        val buffer1 = LongBuffer.wrap(longArrayOf(1L, 2L, 3L))
+        val buffer2 = LongBuffer.wrap(longArrayOf(1L, 2L, 3L))
+        assertEquals(buffer1.hashCode(), buffer2.hashCode())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/LongExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/LongExtTest.kt
@@ -1,0 +1,78 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LongExtTest {
+
+    @Test
+    fun testCompare() {
+        assertEquals(0, Long.compare(123456789L, 123456789L))
+        assertTrue(Long.compare(123456789L, 987654321L) < 0)
+        assertTrue(Long.compare(987654321L, 123456789L) > 0)
+    }
+
+    @Test
+    fun testToBinaryString() {
+        val value = 10L
+        val binaryString = Long.toBinaryString(value)
+        assertEquals("1010", binaryString)
+    }
+
+    @Test
+    fun testToUnsignedString() {
+        val value = -1L
+        val unsignedString = Long.toUnsignedString(value)
+        assertEquals("18446744073709551615", unsignedString)
+    }
+
+    @Test
+    fun testToHexString() {
+        val value = 255L
+        val hexString = Long.toHexString(value)
+        assertEquals("ff", hexString)
+    }
+
+    @Test
+    fun testNumberOfLeadingZeros() {
+        val value = 0b0000_1000L
+        val leadingZeros = Long.numberOfLeadingZeros(value)
+        assertEquals(60, leadingZeros)
+    }
+
+    @Test
+    fun testNumberOfTrailingZeros() {
+        val value = 0b1000_0000L
+        val trailingZeros = Long.numberOfTrailingZeros(value)
+        assertEquals(7, trailingZeros)
+    }
+
+    @Test
+    fun testBitCount() {
+        val value = 0b1010_1010L
+        val bitCount = Long.bitCount(value)
+        assertEquals(4, bitCount)
+    }
+
+    @Test
+    fun testRotateLeft() {
+        val value = 0b0001_0000L
+        val rotated = Long.rotateLeft(value, 2)
+        assertEquals(0b0100_0000L, rotated)
+    }
+
+    @Test
+    fun testRotateRight() {
+        val value = 0b0001_0000L
+        val rotated = Long.rotateRight(value, 2)
+        assertEquals(0b0000_0100L, rotated)
+    }
+
+    @Test
+    fun testReverseBytes() {
+        val value = 0x1234567890ABCDEFL
+        val reversed = Long.reverseBytes(value)
+        assertEquals(0xEFCDAB9078563412L, reversed)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/MathTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/MathTest.kt
@@ -1,0 +1,43 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MathTest {
+
+    @Test
+    fun testAbs() {
+        assertEquals(10, Math.abs(-10))
+        assertEquals(10, Math.abs(10))
+        assertEquals(0, Math.abs(0))
+    }
+
+    @Test
+    fun testMax() {
+        assertEquals(10, Math.max(10, 5))
+        assertEquals(10, Math.max(5, 10))
+        assertEquals(10, Math.max(10, 10))
+    }
+
+    @Test
+    fun testMin() {
+        assertEquals(5, Math.min(10, 5))
+        assertEquals(5, Math.min(5, 10))
+        assertEquals(5, Math.min(5, 5))
+    }
+
+    @Test
+    fun testPow() {
+        assertEquals(100.0, Math.pow(10.0, 2.0))
+        assertEquals(1.0, Math.pow(10.0, 0.0))
+        assertEquals(0.1, Math.pow(10.0, -1.0))
+    }
+
+    @Test
+    fun testSqrt() {
+        assertEquals(10.0, Math.sqrt(100.0))
+        assertEquals(0.0, Math.sqrt(0.0))
+        assertTrue(Math.sqrt(-1.0).isNaN())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/MutableMapExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/MutableMapExtTest.kt
@@ -1,0 +1,38 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MutableMapExtTest {
+
+    @Test
+    fun testPutIfAbsent() {
+        val map = mutableMapOf<String, String>()
+        map.putIfAbsent("key1", "value1")
+        assertEquals("value1", map["key1"])
+
+        map.putIfAbsent("key1", "value2")
+        assertEquals("value1", map["key1"])
+    }
+
+    @Test
+    fun testRemove() {
+        val map = mutableMapOf("key1" to "value1", "key2" to "value2")
+        map.remove("key1", "value1")
+        assertNull(map["key1"])
+
+        map.remove("key2", "value1")
+        assertEquals("value2", map["key2"])
+    }
+
+    @Test
+    fun testReplace() {
+        val map = mutableMapOf("key1" to "value1")
+        map.replace("key1", "value2")
+        assertEquals("value2", map["key1"])
+
+        map.replace("key2", "value3")
+        assertNull(map["key2"])
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/NullableKeyValueHolderTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/NullableKeyValueHolderTest.kt
@@ -1,0 +1,35 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class NullableKeyValueHolderTest {
+
+    @Test
+    fun testGetKey() {
+        val holder = NullableKeyValueHolder("key", "value")
+        assertEquals("key", holder.key)
+
+        val nullKeyHolder = NullableKeyValueHolder(null, "value")
+        assertNull(nullKeyHolder.key)
+    }
+
+    @Test
+    fun testGetValue() {
+        val holder = NullableKeyValueHolder("key", "value")
+        assertEquals("value", holder.value)
+
+        val nullValueHolder = NullableKeyValueHolder("key", null)
+        assertNull(nullValueHolder.value)
+    }
+
+    @Test
+    fun testSetValue() {
+        val holder = NullableKeyValueHolder("key", "value")
+        assertFailsWith<UnsupportedOperationException> {
+            holder.setValue("newValue")
+        }
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ObjectsTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ObjectsTest.kt
@@ -1,0 +1,31 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ObjectsTest {
+
+    @Test
+    fun testEquals() {
+        assertEquals(true, Objects.equals("test", "test"))
+        assertEquals(false, Objects.equals("test", "TEST"))
+        assertEquals(false, Objects.equals("test", null))
+        assertEquals(false, Objects.equals(null, "test"))
+        assertEquals(true, Objects.equals(null, null))
+    }
+
+    @Test
+    fun testHash() {
+        assertEquals(0, Objects.hash())
+        assertEquals(1, Objects.hash(1))
+        assertEquals(Objects.hash(1, 2, 3), Objects.hash(1, 2, 3))
+        assertNotEquals(Objects.hash(1, 2, 3), Objects.hash(3, 2, 1))
+    }
+
+    @Test
+    fun testToString() {
+        assertEquals("test", Objects.toString("test"))
+        assertEquals("null", Objects.toString(null))
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/OptionalTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/OptionalTest.kt
@@ -1,0 +1,101 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+class OptionalTest {
+
+    @Test
+    fun testOf() {
+        val value = "test"
+        val optional = Optional.of(value)
+        assertTrue(optional.isPresent)
+        assertEquals(value, optional.get())
+    }
+
+    @Test
+    fun testOfNullable() {
+        val value = "test"
+        val optional = Optional.ofNullable(value)
+        assertTrue(optional.isPresent)
+        assertEquals(value, optional.get())
+
+        val emptyOptional = Optional.ofNullable<String>(null)
+        assertFalse(emptyOptional.isPresent)
+    }
+
+    @Test
+    fun testEmpty() {
+        val emptyOptional = Optional.empty<String>()
+        assertFalse(emptyOptional.isPresent)
+    }
+
+    @Test
+    fun testGet() {
+        val value = "test"
+        val optional = Optional.of(value)
+        assertEquals(value, optional.get())
+
+        val emptyOptional = Optional.empty<String>()
+        assertFailsWith<NoSuchElementException> { emptyOptional.get() }
+    }
+
+    @Test
+    fun testIsPresent() {
+        val value = "test"
+        val optional = Optional.of(value)
+        assertTrue(optional.isPresent)
+
+        val emptyOptional = Optional.empty<String>()
+        assertFalse(emptyOptional.isPresent)
+    }
+
+    @Test
+    fun testIfPresent() {
+        val value = "test"
+        val optional = Optional.of(value)
+        var result: String? = null
+        optional.ifPresent { result = it }
+        assertEquals(value, result)
+
+        val emptyOptional = Optional.empty<String>()
+        result = null
+        emptyOptional.ifPresent { result = it }
+        assertNull(result)
+    }
+
+    @Test
+    fun testOrElse() {
+        val value = "test"
+        val optional = Optional.of(value)
+        assertEquals(value, optional.orElse("default"))
+
+        val emptyOptional = Optional.empty<String>()
+        assertEquals("default", emptyOptional.orElse("default"))
+    }
+
+    @Test
+    fun testOrElseGet() {
+        val value = "test"
+        val optional = Optional.of(value)
+        assertEquals(value, optional.orElseGet { "default" })
+
+        val emptyOptional = Optional.empty<String>()
+        assertEquals("default", emptyOptional.orElseGet { "default" })
+    }
+
+    @Test
+    fun testOrElseThrow() {
+        val value = "test"
+        val optional = Optional.of(value)
+        assertEquals(value, optional.orElseThrow())
+
+        val emptyOptional = Optional.empty<String>()
+        assertFailsWith<NoSuchElementException> { emptyOptional.orElseThrow() }
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/PriorityQueueTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/PriorityQueueTest.kt
@@ -1,0 +1,52 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PriorityQueueTest {
+
+    @Test
+    fun testAdd() {
+        val pq = PriorityQueue<Int>()
+        pq.offer(3)
+        pq.offer(1)
+        pq.offer(2)
+        assertEquals(3, pq.size())
+    }
+
+    @Test
+    fun testRemove() {
+        val pq = PriorityQueue<Int>()
+        pq.offer(3)
+        pq.offer(1)
+        pq.offer(2)
+        assertEquals(1, pq.poll())
+        assertEquals(2, pq.poll())
+        assertEquals(3, pq.poll())
+        assertNull(pq.poll())
+    }
+
+    @Test
+    fun testPeek() {
+        val pq = PriorityQueue<Int>()
+        pq.offer(3)
+        pq.offer(1)
+        pq.offer(2)
+        assertEquals(1, pq.peek())
+        pq.poll()
+        assertEquals(2, pq.peek())
+    }
+
+    @Test
+    fun testPoll() {
+        val pq = PriorityQueue<Int>()
+        pq.offer(3)
+        pq.offer(1)
+        pq.offer(2)
+        assertEquals(1, pq.poll())
+        assertEquals(2, pq.poll())
+        assertEquals(3, pq.poll())
+        assertNull(pq.poll())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ReferenceQueueTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ReferenceQueueTest.kt
@@ -1,0 +1,26 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ReferenceQueueTest {
+
+    @Test
+    fun testPoll() {
+        val queue = ReferenceQueue<String>()
+        val ref = Reference("test", queue)
+        ref.enqueue()
+        assertTrue(queue.poll() === ref)
+        assertNull(queue.poll())
+    }
+
+    @Test
+    fun testRemove() {
+        val queue = ReferenceQueue<String>()
+        val ref = Reference("test", queue)
+        ref.enqueue()
+        assertTrue(queue.remove() === ref)
+        assertNull(queue.remove())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ReferenceTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ReferenceTest.kt
@@ -1,0 +1,23 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ReferenceTest {
+
+    @Test
+    fun testGet() {
+        val referent = "test"
+        val reference = Reference(referent)
+        assertEquals(referent, reference.get())
+    }
+
+    @Test
+    fun testClear() {
+        val referent = "test"
+        val reference = Reference(referent)
+        reference.clear()
+        assertNull(reference.get())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ShortExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ShortExtTest.kt
@@ -1,0 +1,29 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ShortExtTest {
+
+    @Test
+    fun testCompare() {
+        assertEquals(0, Short.compare(123.toShort(), 123.toShort()))
+        assertTrue(Short.compare(123.toShort(), 321.toShort()) < 0)
+        assertTrue(Short.compare(321.toShort(), 123.toShort()) > 0)
+    }
+
+    @Test
+    fun testToUnsignedInt() {
+        val value: Short = -1
+        val unsignedInt = Short.toUnsignedInt(value)
+        assertEquals(65535, unsignedInt)
+    }
+
+    @Test
+    fun testToUnsignedLong() {
+        val value: Short = -1
+        val unsignedLong = Short.toUnsignedLong(value)
+        assertEquals(65535L, unsignedLong)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/SpliteratorsTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/SpliteratorsTest.kt
@@ -1,0 +1,99 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SpliteratorsTest {
+
+    @Test
+    fun testSpliterator() {
+        val array = arrayOf(1, 2, 3, 4, 5)
+        val spliterator = Spliterators.ArraySpliterator(array, Spliterator.ORDERED)
+
+        val list = mutableListOf<Int>()
+        while (spliterator.tryAdvance { list.add(it) }) {
+        }
+
+        assertEquals(listOf(1, 2, 3, 4, 5), list)
+    }
+
+    @Test
+    fun testSpliteratorUnknownSize() {
+        val iterator = listOf(1, 2, 3, 4, 5).iterator()
+        val spliterator = Spliterators.IteratorSpliterator(iterator, Spliterator.ORDERED)
+
+        val list = mutableListOf<Int>()
+        while (spliterator.tryAdvance { list.add(it) }) {
+        }
+
+        assertEquals(listOf(1, 2, 3, 4, 5), list)
+    }
+
+    @Test
+    fun testSpliteratorTrySplit() {
+        val array = arrayOf(1, 2, 3, 4, 5)
+        val spliterator = Spliterators.ArraySpliterator(array, Spliterator.ORDERED)
+
+        val split = spliterator.trySplit()
+        assertTrue(split != null)
+
+        val list1 = mutableListOf<Int>()
+        while (spliterator.tryAdvance { list1.add(it) }) {
+        }
+
+        val list2 = mutableListOf<Int>()
+        while (split!!.tryAdvance { list2.add(it) }) {
+        }
+
+        assertEquals(listOf(3, 4, 5), list1)
+        assertEquals(listOf(1, 2), list2)
+    }
+
+    @Test
+    fun testSpliteratorUnknownSizeTrySplit() {
+        val iterator = listOf(1, 2, 3, 4, 5).iterator()
+        val spliterator = Spliterators.IteratorSpliterator(iterator, Spliterator.ORDERED)
+
+        val split = spliterator.trySplit()
+        assertTrue(split != null)
+
+        val list1 = mutableListOf<Int>()
+        while (spliterator.tryAdvance { list1.add(it) }) {
+        }
+
+        val list2 = mutableListOf<Int>()
+        while (split!!.tryAdvance { list2.add(it) }) {
+        }
+
+        assertTrue(list1.isNotEmpty())
+        assertTrue(list2.isNotEmpty())
+    }
+
+    @Test
+    fun testSpliteratorCharacteristics() {
+        val array = arrayOf(1, 2, 3, 4, 5)
+        val spliterator = Spliterators.ArraySpliterator(array, Spliterator.ORDERED or Spliterator.SIZED)
+
+        assertTrue(spliterator.hasCharacteristics(Spliterator.ORDERED))
+        assertTrue(spliterator.hasCharacteristics(Spliterator.SIZED))
+        assertFalse(spliterator.hasCharacteristics(Spliterator.SORTED))
+    }
+
+    @Test
+    fun testSpliteratorEstimateSize() {
+        val array = arrayOf(1, 2, 3, 4, 5)
+        val spliterator = Spliterators.ArraySpliterator(array, Spliterator.ORDERED or Spliterator.SIZED)
+
+        assertEquals(5, spliterator.estimateSize())
+    }
+
+    @Test
+    fun testSpliteratorUnknownSizeEstimateSize() {
+        val iterator = listOf(1, 2, 3, 4, 5).iterator()
+        val spliterator = Spliterators.IteratorSpliterator(iterator, Spliterator.ORDERED)
+
+        assertEquals(Long.MAX_VALUE, spliterator.estimateSize())
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/StandardCharsetsTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/StandardCharsetsTest.kt
@@ -1,0 +1,59 @@
+package org.gnit.lucenekmp.jdkport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StandardCharsetsTest {
+
+    @Test
+    fun testUTF8Charset() {
+        val charset = StandardCharsets.UTF_8
+        assertEquals("UTF-8", charset.name())
+        assertEquals(setOf("UTF8", "unicode-1-1-utf-8"), StandardCharsets.aliases_UTF_8())
+    }
+
+    @Test
+    fun testUTF8CharsetDecode() {
+        val charset = StandardCharsets.UTF_8
+        val input = byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F) // "Hello" in UTF-8
+        val output = charset.decode(input)
+        assertEquals("Hello", output)
+    }
+
+    @Test
+    fun testUTF8CharsetEncode() {
+        val charset = StandardCharsets.UTF_8
+        val input = "Hello"
+        val output = charset.encode(input)
+        assertEquals(byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F).toList(), output.toList())
+    }
+
+    @Test
+    fun testLATIN1Charset() {
+        val charset = StandardCharsets.LATIN1
+        assertEquals("ISO-8859-1", charset.name())
+    }
+
+    @Test
+    fun testLATIN1CharsetDecode() {
+        val charset = StandardCharsets.LATIN1
+        val input = byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F) // "Hello" in ISO-8859-1
+        val output = charset.decode(input)
+        assertEquals("Hello", output)
+    }
+
+    @Test
+    fun testLATIN1CharsetEncode() {
+        val charset = StandardCharsets.LATIN1
+        val input = "Hello"
+        val output = charset.encode(input)
+        assertEquals(byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F).toList(), output.toList())
+    }
+
+    @Test
+    fun testDefaultCharset() {
+        val charset = Charset.defaultCharset()
+        assertEquals(StandardCharsets.UTF_8, charset)
+    }
+}


### PR DESCRIPTION
Below is the task description to Copilot Workspace which was used to generate this pull request:


I'm porting apache lucene from java to platform agnostic kotlin common to make multiplatform library which suppports Android, iOS, and JVM(server).

During the porting process there was JDK classes which is used in Java lucene but have no equivalent pair in kotlin standard library (standard library of kotlin common). To smooth the porting process I decided to port also those JDK classes into package org.gnit.lucenekmp.jdkport.

There are some edge case such as Double. jdk and kotlin standard lib both has Double class but the some jdk Double functions are not found in kotlin ones. In such case, I created a kotlin file contains extension functions to fill the functionality pair gap. The file name convention for extension function is for example "for Double class, kt file is named DoubleExt.kt"

So far, some JDK classes are ported and some of them has unit tests. Unit tests for classes in jdkport package are made alphabetical order starting form ArrayDequeExt.kt, then ArraySupport.kt ... etc. I skip creating tests for interfaces and abstract classes.

Port of Classloader.java and ServiceLoader.java is does as skeleton with no operation functions because I still did not decide how to walk around this JVM specific feature in kotlin common. So creating unit tests for Classloader and ServiceLoader is also skipped for now.

This is the background of the project and current progress which is related to my following request.

This time, my request is this: create Unit tests for following classes:
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Collections.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Comparators.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/CRC32.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/DoubleExt.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Files.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FilterInputStream.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FilterOutputStream.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FloatBuffer.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FloatExt.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FutureTask.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/InputStreamReader.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/IntExt.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/KIOSinkOutputStream.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceBufferedReader.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceInputStream.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/LongBuffer.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/LongExt.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Math.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/MutableMapExt.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/NullableKeyValueHolder.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Objects.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Optional.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/PriorityQueue.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Reference.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/ReferenceQueue.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/ShortExt.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Spliterators.kt
core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/StandardCharsets.kt


When you create tests for functions of a class, if the class is subclass of abstract class and if you find any functions are not overidden by the sub class, create test for the function of the super class.

create test files in core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport

Test class/file name convention is for example, for System.kt, SystemTest.kt. And for IntExt.kt file, IntExtTest.kt.

Create unit tests following above requirement, run the test by ./gradlew allTest command if test fails, review both implementation of the tested function and the test code. Verify tested function is correctly implemented. Verify if the test assertion is correctly expecting the outcome of the unit test. 

JDK ported classes are ported by copy and pasting in intelij idea with automatic java to kotlin conversion feature. So in most cases, logic is directly mapped from jdk and does not need to be changed. So when test fails, do not change the fundamental implementation logic but try to find mistakes caused by java to kotlin conversion. Always keep in mind that this is kotlin common project and never use jdk specific feature in the both tested and test code when you make change. The code also needs to work in iOS. Avoid expect/actual pattern to implement things but implement all of them by using just kotlin standard library for common target.

ok, then start implementing unit test and iterate over adjusting codes until all the tests pass.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nehemiaharchives/lucene-kmp?shareId=XXXX-XXXX-XXXX-XXXX).