### PR TITLE
Add unit tests for DoubleExt properties

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/DoubleExtTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/DoubleExtTest.kt
@@ -49,4 +49,18 @@ class DoubleExtTest {
         assertTrue(!Double.isFinite(Double.NaN))
     }
 
+    @Test
+    fun testMinExponent() {
+        assertEquals(-1022, Double.MIN_EXPONENT)
+    }
+
+    @Test
+    fun testPrecision() {
+        assertEquals(53, Double.PRECISION)
+    }
+
+    @Test
+    fun testMaxExponent() {
+        assertEquals(1023, Double.MAX_EXPONENT)
+    }
 }


### PR DESCRIPTION
This commit adds unit tests for the following properties in `DoubleExt.kt`:
- MIN_EXPONENT
- PRECISION
- MAX_EXPONENT

I added the new tests to `DoubleExtTest.kt` and they all pass successfully.

Note: During testing, I observed unrelated failures in the `org.gnit.lucenekmp.util` package due to `java.lang.UnsupportedClassVersionError`. This appears to be a pre-existing environment or configuration issue and is not related to the changes in this commit.