### PR TITLE
Add unit tests for KIOSourceBufferedReader

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceBufferedReaderTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceBufferedReaderTest.kt
@@ -445,7 +445,7 @@ class KIOSourceBufferedReaderTest {
         assertEquals('b'.code, reader.read(), "Reset to 'b' after reading 10 chars within larger limit")
         var count = 1
         while(reader.read() != -1) count++
-        assertEquals(13, count, "Should read remaining 13 chars (c..o) after reset")
+        assertEquals(14, count, "Should read remaining 14 chars (b..o) after reset")
     }
 
     @Test
@@ -491,9 +491,9 @@ class KIOSourceBufferedReaderTest {
         assertEquals(3L, skipped)
         assertEquals('d'.code, reader.read(), "Next char should be 'd' after skipping 3")
 
-        skipped = reader.skip(2) // Skip "de"
+        skipped = reader.skip(2) // Skip "ef" according to JDK semantics
         assertEquals(2L, skipped)
-        assertEquals('f'.code, reader.read(), "Next char should be 'f' after skipping 2 more")
+        assertEquals('g'.code, reader.read(), "Next char should be 'g' after skipping 2 more")
     }
 
     @Test


### PR DESCRIPTION
This commit introduces a comprehensive test suite for the KIOSourceBufferedReader class located in `org.gnit.lucenekmp.jdkport`.

The tests cover the following methods and functionalities:
- `read()`: Single character reading, EOF, multi-byte characters, small buffer, closed stream.
- `read(char[], int, int)`: Array reading, offsets, partial reads, EOF, invalid parameters, closed stream.
- `readLine()`: Various line terminators, empty lines, long lines, small buffers, closed stream.
- `ready()`: Buffer/source data status, EOF, empty source, closed stream.
- `mark()` & `reset()`: Basic marking/resetting, read-ahead limits, buffer interactions (including reallocation), `markSupported()`, closed stream behavior.
- `skip()`: Basic skipping, skipping 0/negative values, EOF handling, buffer interaction, closed stream.
- `close()`: Ensures operations fail after close and closing an already closed stream is a no-op.

The tests were added to `core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/KIOSourceBufferedReaderTest.kt`.

Note: Due to persistent issues, I was unable to run and verify these tests automatically. You will need to verify them manually.