### PR TITLE
Fix Optional.of null behavior

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Optional.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/Optional.kt
@@ -323,7 +323,7 @@ class Optional<T> private constructor(value: T?) {
          * @throws NullPointerException if value is null
          */
         fun <T> of(value: T): Optional<T> {
-            return Optional(checkNotNull(value))
+            return Optional(value ?: throw NullPointerException())
         }
 
         /**


### PR DESCRIPTION
## Summary
- match Java semantics for Optional.of when passed null
- add NullPointerException for Optional.of(null)

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test`


------
https://chatgpt.com/codex/tasks/task_e_68429f9eb810832ba399ebacfeab6e26