### PR TITLE
Add tests for NullableKeyValueHolder

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/NullableKeyValueHolderTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/NullableKeyValueHolderTest.kt
@@ -1,9 +1,13 @@
 package org.gnit.lucenekmp.jdkport
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+
+private val logger = KotlinLogging.logger {}
 
 class NullableKeyValueHolderTest {
 
@@ -31,5 +35,46 @@ class NullableKeyValueHolderTest {
         assertFailsWith<UnsupportedOperationException> {
             holder.setValue("newValue")
         }
+    }
+
+    @Test
+    fun testEqualsAndHashCode() {
+        val holder1 = NullableKeyValueHolder("k", "v")
+        val holder2 = NullableKeyValueHolder("k", "v")
+        assertEquals(holder1, holder2)
+        assertEquals(holder1.hashCode(), holder2.hashCode())
+
+        val holder3 = NullableKeyValueHolder<String?, String?>(null, null)
+        val holder4 = NullableKeyValueHolder<String?, String?>(null, null)
+        assertEquals(holder3, holder4)
+        assertEquals(holder3.hashCode(), holder4.hashCode())
+
+        assertNotEquals(holder1, holder3)
+        logger.debug { "equals and hashCode tested" }
+    }
+
+    @Test
+    fun testToString() {
+        val holder = NullableKeyValueHolder("a", "b")
+        assertEquals("a=b", holder.toString())
+
+        val nullHolder = NullableKeyValueHolder<String?, String?>(null, null)
+        assertEquals("null=null", nullHolder.toString())
+    }
+
+    @Test
+    fun testEntryConstructor() {
+        val map = mutableMapOf("x" to "y")
+        val entry = map.entries.first()
+        val holder = NullableKeyValueHolder(entry)
+        assertEquals("x", holder.key)
+        assertEquals("y", holder.value)
+
+        val nullMap = mutableMapOf<String?, String?>()
+        nullMap[null] = null
+        val nullEntry = nullMap.entries.first()
+        val nullHolder = NullableKeyValueHolder(nullEntry)
+        assertNull(nullHolder.key)
+        assertNull(nullHolder.value)
     }
 }


### PR DESCRIPTION
## Summary
- expand tests for `NullableKeyValueHolder` to cover equality, hashCode, toString and entry constructor

## Testing
- `./gradlew jvmTest` *(fails: Codex couldn't run certain commands due to environment limitations)*
- `./gradlew linuxX64Test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6842e00310dc832bb906af47c31a9106