### PR TITLE
Add IntroSorter test suite

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/TestIntroSorter.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/TestIntroSorter.kt
@@ -1,0 +1,20 @@
+package org.gnit.lucenekmp.util
+
+import kotlin.test.Test
+
+class TestIntroSorter : BaseSortTestCase(false) {
+    override fun newSorter(arr: Array<Entry>): Sorter {
+        return ArrayIntroSorter(arr, Comparator { a, b -> a.compareTo(b) })
+    }
+
+    // Kotlin requires explicit test annotations on inherited tests
+    @Test fun testEmptyIntroSorter() = testEmpty()
+    @Test fun testOneIntroSorter() = testOne()
+    @Test fun testTwoIntroSorter() = testTwo()
+    @Test fun testRandomIntroSorter() = testRandom()
+    @Test fun testRandomLowCardinalityIntroSorter() = testRandomLowCardinality()
+    @Test fun testAscendingIntroSorter() = testAscending()
+    @Test fun testAscendingSequencesIntroSorter() = testAscendingSequences()
+    @Test fun testDescendingIntroSorter() = testDescending()
+    @Test fun testStrictlyDescendingIntroSorter() = testStrictlyDescending()
+}


### PR DESCRIPTION
## Summary
- port IntroSorter test from Apache Lucene
- exercise IntroSorter through BaseSortTestCase

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test`

------
https://chatgpt.com/codex/tasks/task_e_6848f888dffc832ba9a325a8c745dfd9