### PR TITLE
Port TestInPlaceMergeSorter

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/ArrayInPlaceMergeSorter.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/ArrayInPlaceMergeSorter.kt
@@ -1,0 +1,20 @@
+package org.gnit.lucenekmp.util
+
+/**
+ * An [InPlaceMergeSorter] for object arrays.
+ *
+ * @lucene.internal
+ */
+internal class ArrayInPlaceMergeSorter<T>(
+    private val arr: Array<T>,
+    private val comparator: Comparator<in T>
+) : InPlaceMergeSorter() {
+    /** Create a new [ArrayInPlaceMergeSorter]. */
+    override fun compare(i: Int, j: Int): Int {
+        return comparator.compare(arr[i], arr[j])
+    }
+
+    override fun swap(i: Int, j: Int) {
+        ArrayUtil.swap(arr, i, j)
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/TestInPlaceMergeSorter.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/TestInPlaceMergeSorter.kt
@@ -1,0 +1,21 @@
+package org.gnit.lucenekmp.util
+
+import kotlin.test.Test
+
+class TestInPlaceMergeSorter : BaseSortTestCase(true) {
+    override fun newSorter(arr: Array<Entry>): Sorter {
+        return ArrayInPlaceMergeSorter(arr, Comparator { a, b -> a.compareTo(b) })
+    }
+
+    // In Java lucene, tests are inherited from BaseSortTestCase. Kotlin requires
+    // explicit @Test annotations, so we delegate.
+    @Test fun testEmptyInPlaceMergeSorter() = testEmpty()
+    @Test fun testOneInPlaceMergeSorter() = testOne()
+    @Test fun testTwoInPlaceMergeSorter() = testTwo()
+    @Test fun testRandomInPlaceMergeSorter() = testRandom()
+    @Test fun testRandomLowCardinalityInPlaceMergeSorter() = testRandomLowCardinality()
+    @Test fun testAscendingInPlaceMergeSorter() = testAscending()
+    @Test fun testAscendingSequencesInPlaceMergeSorter() = testAscendingSequences()
+    @Test fun testDescendingInPlaceMergeSorter() = testDescending()
+    @Test fun testStrictlyDescendingInPlaceMergeSorter() = testStrictlyDescending()
+}


### PR DESCRIPTION
## Summary
- add `ArrayInPlaceMergeSorter` implementation
- port Lucene's `TestInPlaceMergeSorter`

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test` *(fails to complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6848f83ae104832b86400bdbab2304f1