### PR TITLE
Fix unstable IntArrayDocIdSet bound check test

### DIFF
--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/util/BaseDocIdSetTestCase.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/util/BaseDocIdSetTestCase.kt
@@ -180,7 +180,9 @@ abstract class BaseDocIdSetTestCase<T : DocIdSet> : LuceneTestCase() {
         set.set(42)
         val copy = copyOf(set, 256)
         val from = TestUtil.nextInt(Random, 0, 20)
-        val to = TestUtil.nextInt(Random, from + 23, 256)
+        // use a fixed lower bound of 43 to ensure that all set bits are within
+        // the destination bit set's range
+        val to = TestUtil.nextInt(Random, 43, 256)
         val offset = TestUtil.nextInt(Random, 0, from)
         val dest1 = FixedBitSet(42 - offset + 1)
         val it1 = copy.iterator()!!


### PR DESCRIPTION
## Summary
- use constant 43 lower bound to match Lucene's bound checks

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test` *(fails to show output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68497cb6b31c832bb823a673a6cddbc1