### PR TITLE
Port TestXYLine

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/geo/TestXYLine.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/geo/TestXYLine.kt
@@ -1,0 +1,85 @@
+package org.gnit.lucenekmp.geo
+
+import org.gnit.lucenekmp.tests.geo.ShapeTestUtil
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class TestXYLine : LuceneTestCase() {
+
+    @Test
+    fun testLineNullXs() {
+        assertFailsWith<NullPointerException> {
+            XYLine(null as FloatArray, floatArrayOf(-66f, -65f, -65f, -66f, -66f))
+        }
+    }
+
+    @Test
+    fun testPolygonNullYs() {
+        assertFailsWith<NullPointerException> {
+            XYLine(floatArrayOf(18f, 18f, 19f, 19f, 18f), null as FloatArray)
+        }
+    }
+
+    @Test
+    fun testLineEnoughPoints() {
+        val e = expectThrows(IllegalArgumentException::class) {
+            XYLine(floatArrayOf(18f), floatArrayOf(-66f))
+        }
+        assertTrue(e!!.message!!.contains("at least 2 line points required"))
+    }
+
+    @Test
+    fun testLinesBogus() {
+        val e = expectThrows(IllegalArgumentException::class) {
+            XYLine(floatArrayOf(18f, 18f, 19f, 19f), floatArrayOf(-66f, -65f, -65f, -66f, -66f))
+        }
+        assertTrue(e!!.message!!.contains("must be equal length"))
+    }
+
+    @Test
+    fun testLineNaN() {
+        val e = expectThrows(IllegalArgumentException::class) {
+            XYLine(floatArrayOf(18f, 18f, 19f, Float.NaN, 18f), floatArrayOf(-66f, -65f, -65f, -66f, -66f))
+        }
+        assertTrue(e!!.message!!.contains("invalid value NaN"))
+    }
+
+    @Test
+    fun testLinePositiveInfinite() {
+        val e = expectThrows(IllegalArgumentException::class) {
+            XYLine(floatArrayOf(18f, 18f, 19f, 19f, 18f),
+                floatArrayOf(-66f, Float.POSITIVE_INFINITY, -65f, -66f, -66f))
+        }
+        assertTrue(e!!.message!!.contains("invalid value Inf"))
+    }
+
+    @Test
+    fun testLineNegativeInfinite() {
+        val e = expectThrows(IllegalArgumentException::class) {
+            XYLine(floatArrayOf(18f, 18f, 19f, 19f, 18f),
+                floatArrayOf(-66f, -65f, -65f, Float.NEGATIVE_INFINITY, -66f))
+        }
+        assertTrue(e!!.message!!.contains("invalid value -Inf"))
+    }
+
+    @Test
+    fun testEqualsAndHashCode() {
+        val line = ShapeTestUtil.nextLine()
+        val copy = XYLine(line.getX(), line.getY())
+        assertEquals(line, copy)
+        assertEquals(line.hashCode(), copy.hashCode())
+        val otherLine = ShapeTestUtil.nextLine()
+        if (!line.getX().contentEquals(otherLine.getX()) || !line.getY().contentEquals(otherLine.getY())) {
+            assertNotEquals(line, otherLine)
+            assertNotEquals(line.hashCode(), otherLine.hashCode())
+        } else {
+            assertEquals(line, otherLine)
+            assertEquals(line.hashCode(), otherLine.hashCode())
+        }
+    }
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/ShapeTestUtil.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/ShapeTestUtil.kt
@@ -1,0 +1,24 @@
+package org.gnit.lucenekmp.tests.geo
+
+import org.gnit.lucenekmp.geo.XYLine
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.TestUtil
+import kotlin.random.Random
+
+object ShapeTestUtil {
+    private fun nextFloat(random: Random): Float {
+        return (random.nextFloat() * 2 - 1) * Float.MAX_VALUE
+    }
+
+    fun nextLine(): XYLine {
+        val random = LuceneTestCase.random()
+        val count = TestUtil.nextInt(random, 2, 10)
+        val xs = FloatArray(count)
+        val ys = FloatArray(count)
+        for (i in 0 until count) {
+            xs[i] = nextFloat(random)
+            ys[i] = nextFloat(random)
+        }
+        return XYLine(xs, ys)
+    }
+}


### PR DESCRIPTION
## Summary
- port TestXYLine from Apache Lucene to Kotlin
- add a minimal ShapeTestUtil helper for random XYLine generation

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test` *(fails due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684bcb43c2e0832b9f5f39f4384488ef