### PR TITLE
Add XYPolygon tests

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/geo/TestXYPolygon.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/geo/TestXYPolygon.kt
@@ -1,0 +1,77 @@
+package org.gnit.lucenekmp.geo
+
+import org.gnit.lucenekmp.tests.geo.ShapeTestUtil
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class TestXYPolygon : LuceneTestCase() {
+
+    @Test
+    fun testPolygonLine() {
+        val expected = expectThrows<IllegalArgumentException>(IllegalArgumentException::class) {
+            XYPolygon(floatArrayOf(18f, 18f, 18f), floatArrayOf(-66f, -65f, -66f))
+        }
+        assertTrue(expected!!.message!!.contains("at least 4 polygon points required"))
+    }
+
+    @Test
+    fun testPolygonBogus() {
+        val expected = expectThrows<IllegalArgumentException>(IllegalArgumentException::class) {
+            XYPolygon(floatArrayOf(18f, 18f, 19f, 19f), floatArrayOf(-66f, -65f, -65f, -66f, -66f))
+        }
+        assertTrue(expected!!.message!!.contains("must be equal length"))
+    }
+
+    @Test
+    fun testPolygonNotClosed() {
+        val expected = expectThrows<IllegalArgumentException>(IllegalArgumentException::class) {
+            XYPolygon(floatArrayOf(18f, 18f, 19f, 19f, 19f), floatArrayOf(-66f, -65f, -65f, -66f, -67f))
+        }
+        assertTrue(expected!!.message!!.contains("it must close itself"))
+    }
+
+    @Test
+    fun testPolygonNaN() {
+        val expected = expectThrows<IllegalArgumentException>(IllegalArgumentException::class) {
+            XYPolygon(floatArrayOf(18f, 18f, 19f, Float.NaN, 18f), floatArrayOf(-66f, -65f, -65f, -66f, -66f))
+        }
+        assertTrue(expected!!.message!!.contains("invalid value NaN"))
+    }
+
+    @Test
+    fun testPolygonPositiveInfinite() {
+        val expected = expectThrows<IllegalArgumentException>(IllegalArgumentException::class) {
+            XYPolygon(floatArrayOf(18f, 18f, 19f, 19f, 18f), floatArrayOf(-66f, Float.POSITIVE_INFINITY, -65f, -66f, -66f))
+        }
+        assertTrue(expected!!.message!!.contains("invalid value Inf"))
+    }
+
+    @Test
+    fun testPolygonNegativeInfinite() {
+        val expected = expectThrows<IllegalArgumentException>(IllegalArgumentException::class) {
+            XYPolygon(floatArrayOf(18f, 18f, 19f, 19f, 18f), floatArrayOf(-66f, -65f, -65f, Float.NEGATIVE_INFINITY, -66f))
+        }
+        assertTrue(expected!!.message!!.contains("invalid value -Inf"))
+    }
+
+    @Test
+    fun testEqualsAndHashCode() {
+        val polygon = ShapeTestUtil.nextPolygon()
+        val copy = XYPolygon(polygon.polyX, polygon.polyY, *polygon.getHoles())
+        assertEquals(polygon, copy)
+        assertEquals(polygon.hashCode(), copy.hashCode())
+        val otherPolygon = ShapeTestUtil.nextPolygon()
+        if (!polygon.polyX.contentEquals(otherPolygon.polyX) ||
+            !polygon.polyY.contentEquals(otherPolygon.polyY) ||
+            !polygon.getHoles().contentEquals(otherPolygon.getHoles())) {
+            assertNotEquals(polygon, otherPolygon)
+            assertNotEquals(polygon.hashCode(), otherPolygon.hashCode())
+        } else {
+            assertEquals(polygon, otherPolygon)
+            assertEquals(polygon.hashCode(), otherPolygon.hashCode())
+        }
+    }
+}

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/ShapeTestUtil.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/ShapeTestUtil.kt
@@ -1,0 +1,57 @@
+package org.gnit.lucenekmp.tests.geo
+
+import org.gnit.lucenekmp.geo.XYPolygon
+import org.gnit.lucenekmp.geo.XYRectangle
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.random.Random
+
+/** Utilities for generating random XY shapes for tests. */
+object ShapeTestUtil {
+    private fun nextFloat(random: Random): Float {
+        val sign = if (random.nextBoolean()) 1f else -1f
+        return random.nextFloat() * Float.MAX_VALUE * sign
+    }
+
+    private fun nextBox(random: Random): XYRectangle {
+        var x0 = nextFloat(random)
+        var x1 = nextFloat(random)
+        while (x0 == x1) {
+            x1 = nextFloat(random)
+        }
+        var y0 = nextFloat(random)
+        var y1 = nextFloat(random)
+        while (y0 == y1) {
+            y1 = nextFloat(random)
+        }
+        if (x1 < x0) {
+            val tmp = x0
+            x0 = x1
+            x1 = tmp
+        }
+        if (y1 < y0) {
+            val tmp = y0
+            y0 = y1
+            y1 = tmp
+        }
+        return XYRectangle(x0, x1, y0, y1)
+    }
+
+    private fun trianglePolygon(box: XYRectangle): XYPolygon {
+        val polyX = floatArrayOf(box.minX, box.maxX, box.maxX, box.minX)
+        val polyY = floatArrayOf(box.minY, box.minY, box.maxY, box.minY)
+        return XYPolygon(polyX, polyY)
+    }
+
+    private fun boxPolygon(box: XYRectangle): XYPolygon {
+        val polyX = floatArrayOf(box.minX, box.maxX, box.maxX, box.minX, box.minX)
+        val polyY = floatArrayOf(box.minY, box.minY, box.maxY, box.maxY, box.minY)
+        return XYPolygon(polyX, polyY)
+    }
+
+    /** Returns a simple random polygon for testing. */
+    fun nextPolygon(): XYPolygon {
+        val random = LuceneTestCase.random()
+        val box = nextBox(random)
+        return if (random.nextBoolean()) boxPolygon(box) else trianglePolygon(box)
+    }
+}


### PR DESCRIPTION
## Summary
- add ShapeTestUtil helper to build simple random XY polygons
- test XYPolygon input validation and equality

## Testing
- `./gradlew jvmTest --no-daemon`
- `./gradlew linuxX64Test --no-daemon` *(failed: environment didn't finish)*

------
https://chatgpt.com/codex/tasks/task_e_684bcb2923bc832b86db42dfbb1bddb8