### PR TITLE
Port TestLatLonPoint from Lucene

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/document/Field.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/document/Field.kt
@@ -56,6 +56,10 @@ open class Field : IndexableField {
     /** Field's value  */
     protected lateinit var fieldsData: Any
 
+    protected fun isFieldsDataInitialized(): Boolean {
+        return this::fieldsData.isInitialized
+    }
+
     /**
      * Expert: creates a field with no initial value. This is intended to be used by custom [ ] sub-classes with pre-configured [IndexableFieldType]s.
      *

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/document/LatLonPoint.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/document/LatLonPoint.kt
@@ -78,7 +78,7 @@ class LatLonPoint(name: String, latitude: Double, longitude: Double) : Field(nam
     fun setLocationValue(latitude: Double, longitude: Double) {
         val bytes: ByteArray
 
-        if (fieldsData == null) {
+        if (!isFieldsDataInitialized()) {
             bytes = ByteArray(8)
             fieldsData = BytesRef(bytes)
         } else {

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/PointRangeQuery.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/PointRangeQuery.kt
@@ -46,11 +46,13 @@ abstract class PointRangeQuery protected constructor(
     val field: String
     val numDims: Int
     val bytesPerDim: Int
-    var lowerPoint: ByteArray
-        get() = lowerPoint.copyOf()
+    var lowerPoint: ByteArray = lowerPoint
+        private set
+        get() = field.copyOf()
 
-    var upperPoint: ByteArray
-        get() = upperPoint.copyOf()
+    var upperPoint: ByteArray = upperPoint
+        private set
+        get() = field.copyOf()
 
     /**
      * Expert: create a multidimensional range query for point values.
@@ -76,9 +78,6 @@ abstract class PointRangeQuery protected constructor(
         }
         this.numDims = numDims
         this.bytesPerDim = lowerPoint.size / numDims
-
-        this.lowerPoint = lowerPoint
-        this.upperPoint = upperPoint
     }
 
     override fun visit(visitor: QueryVisitor) {

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/document/TestLatLonPoint.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/document/TestLatLonPoint.kt
@@ -1,0 +1,29 @@
+package org.gnit.lucenekmp.document
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+
+/** Simple tests for [LatLonPoint]. */
+class TestLatLonPoint : LuceneTestCase() {
+    @Test
+    fun testToString() {
+        // looks crazy due to lossiness
+        assertEquals(
+            "LatLonPoint <field:18.313693958334625,-65.22744401358068>",
+            LatLonPoint("field", 18.313694, -65.227444).toString()
+        )
+
+        // looks crazy due to lossiness
+        assertEquals(
+            "field:[18.000000016763806 TO 18.999999999068677],[-65.9999999217689 TO -65.00000006519258]",
+            LatLonPoint.newBoxQuery("field", 18.0, 19.0, -66.0, -65.0).toString()
+        )
+
+        // distance query does not quantize inputs
+        assertEquals(
+            "field:18.0,19.0 +/- 25.0 meters",
+            LatLonPoint.newDistanceQuery("field", 18.0, 19.0, 25.0).toString()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- port Lucene's `TestLatLonPoint` to Kotlin multiplatform
- check field initialization before writing bytes
- avoid recursion in `PointRangeQuery` getters
- ensure tests run on all platforms

## Testing
- `./gradlew jvmTest --no-daemon` *(fails: Plugin artifact not resolved)*
- `./gradlew linuxX64Test --no-daemon` *(not run due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_684b9aa2f1b0832bb512b7a3d9aa74ad