### PR TITLE
Port TestRoaringDocIdSet

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/TestRoaringDocIdSet.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/TestRoaringDocIdSet.kt
@@ -1,0 +1,22 @@
+package org.gnit.lucenekmp.util
+
+import org.gnit.lucenekmp.jdkport.BitSet
+import org.gnit.lucenekmp.tests.util.BaseDocIdSetTestCase
+import kotlin.test.assertEquals
+
+class TestRoaringDocIdSet : BaseDocIdSetTestCase<RoaringDocIdSet>() {
+    override fun copyOf(bs: BitSet, length: Int): RoaringDocIdSet {
+        val builder = RoaringDocIdSet.Builder(length)
+        var i = bs.nextSetBit(0)
+        while (i != -1) {
+            builder.add(i)
+            i = bs.nextSetBit(i + 1)
+        }
+        return builder.build()
+    }
+
+    override fun assertEqualsDocSet(numBits: Int, ds1: BitSet, ds2: RoaringDocIdSet) {
+        super.assertEqualsDocSet(numBits, ds1, ds2)
+        assertEquals(ds1.cardinality(), ds2.cardinality())
+    }
+}

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/util/BaseDocIdSetTestCase.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/util/BaseDocIdSetTestCase.kt
@@ -96,7 +96,7 @@ abstract class BaseDocIdSetTestCase<T : DocIdSet> : LuceneTestCase() {
     }
 
     /** Assert that the content of the DocIdSet is the same as the content of the BitSet. */
-    fun assertEqualsDocSet(numBits: Int, ds1: BitSet, ds2: T) {
+    open fun assertEqualsDocSet(numBits: Int, ds1: BitSet, ds2: T) {
         val random = Random.Default
         var it2: DocIdSetIterator? = ds2.iterator()
         if (it2 == null) {


### PR DESCRIPTION
## Summary
- port `TestRoaringDocIdSet` from upstream lucene
- allow overriding `assertEqualsDocSet` in `BaseDocIdSetTestCase`

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test` *(fails: process terminated due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684b92dca870832bab953efb5579f5f1