### PR TITLE
Port TestCircle2D

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/geo/TestCircle2D.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/geo/TestCircle2D.kt
@@ -1,0 +1,198 @@
+package org.gnit.lucenekmp.geo
+
+import org.gnit.lucenekmp.index.PointValues
+import org.gnit.lucenekmp.tests.geo.GeoTestUtil
+import org.gnit.lucenekmp.tests.geo.ShapeTestUtil
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.jdkport.StrictMath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class TestCircle2D : LuceneTestCase() {
+    @Test
+    fun testTriangleDisjoint() {
+        val circle2D = if (random().nextBoolean()) {
+            val circle = Circle(0.0, 0.0, 100.0)
+            LatLonGeometry.create(circle)
+        } else {
+            val xyCircle = XYCircle(0f, 0f, 1f)
+            XYGeometry.create(xyCircle)
+        }
+        val ax = 4.0
+        val ay = 4.0
+        val bx = 5.0
+        val by = 5.0
+        val cx = 5.0
+        val cy = 4.0
+        assertFalse(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+        assertFalse(circle2D.intersectsLine(ax, ay, bx, by))
+        assertFalse(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+        assertFalse(circle2D.containsLine(ax, ay, bx, by))
+        assertEquals(
+            Component2D.WithinRelation.DISJOINT,
+            circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+        )
+    }
+
+    @Test
+    fun testTriangleIntersects() {
+        val circle2D = if (random().nextBoolean()) {
+            val circle = Circle(0.0, 0.0, 1_000_000.0)
+            LatLonGeometry.create(circle)
+        } else {
+            val xyCircle = XYCircle(0f, 0f, 10f)
+            XYGeometry.create(xyCircle)
+        }
+        val ax = -20.0
+        val ay = 1.0
+        val bx = 20.0
+        val by = 1.0
+        val cx = 0.0
+        val cy = 90.0
+        assertTrue(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+        assertTrue(circle2D.intersectsLine(ax, ay, bx, by))
+        assertFalse(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+        assertFalse(circle2D.containsLine(ax, ay, bx, by))
+        assertEquals(
+            Component2D.WithinRelation.NOTWITHIN,
+            circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+        )
+    }
+
+    @Test
+    fun testTriangleDateLineIntersects() {
+        val circle2D = LatLonGeometry.create(Circle(0.0, 179.0, 222400.0))
+        val ax = -179.0
+        val ay = 1.0
+        val bx = -179.0
+        val by = -1.0
+        val cx = -178.0
+        val cy = 0.0
+        assertTrue(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+        assertTrue(circle2D.intersectsLine(ax, ay, bx, by))
+        assertFalse(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+        assertFalse(circle2D.containsLine(ax, ay, bx, by))
+        assertEquals(
+            Component2D.WithinRelation.NOTWITHIN,
+            circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+        )
+    }
+
+    @Test
+    fun testTriangleContains() {
+        val circle2D = if (random().nextBoolean()) {
+            val circle = Circle(0.0, 0.0, 1_000_000.0)
+            LatLonGeometry.create(circle)
+        } else {
+            val xyCircle = XYCircle(0f, 0f, 1f)
+            XYGeometry.create(xyCircle)
+        }
+        val ax = 0.25
+        val ay = 0.25
+        val bx = 0.5
+        val by = 0.5
+        val cx = 0.5
+        val cy = 0.25
+        assertTrue(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+        assertTrue(circle2D.intersectsLine(ax, ay, bx, by))
+        assertTrue(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+        assertTrue(circle2D.containsLine(ax, ay, bx, by))
+        assertEquals(
+            Component2D.WithinRelation.NOTWITHIN,
+            circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+        )
+    }
+
+    @Test
+    fun testTriangleWithin() {
+        val circle2D = if (random().nextBoolean()) {
+            val circle = Circle(0.0, 0.0, 1000.0)
+            LatLonGeometry.create(circle)
+        } else {
+            val xyCircle = XYCircle(0f, 0f, 1f)
+            XYGeometry.create(xyCircle)
+        }
+        val ax = -20.0
+        val ay = -20.0
+        val bx = 20.0
+        val by = -20.0
+        val cx = 0.0
+        val cy = 20.0
+        assertTrue(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+        assertFalse(circle2D.intersectsLine(bx, by, cx, cy))
+        assertFalse(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+        assertFalse(circle2D.containsLine(bx, by, cx, cy))
+        assertEquals(
+            Component2D.WithinRelation.CANDIDATE,
+            circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+        )
+    }
+
+    @Test
+    fun testRandomTriangles() {
+        val circle2D = if (random().nextBoolean()) {
+            val circle = GeoTestUtil.nextCircle()
+            LatLonGeometry.create(circle)
+        } else {
+            val circle = ShapeTestUtil.nextCircle()
+            XYGeometry.create(circle)
+        }
+        for (i in 0 until 100) {
+            val ax = GeoTestUtil.nextLongitude()
+            val ay = GeoTestUtil.nextLatitude()
+            val bx = GeoTestUtil.nextLongitude()
+            val by = GeoTestUtil.nextLatitude()
+            val cx = GeoTestUtil.nextLongitude()
+            val cy = GeoTestUtil.nextLatitude()
+
+            val tMinX = StrictMath.min(StrictMath.min(ax, bx), cx)
+            val tMaxX = StrictMath.max(StrictMath.max(ax, bx), cx)
+            val tMinY = StrictMath.min(StrictMath.min(ay, by), cy)
+            val tMaxY = StrictMath.max(StrictMath.max(ay, by), cy)
+
+            val r = circle2D.relate(tMinX, tMaxX, tMinY, tMaxY)
+            if (r == PointValues.Relation.CELL_OUTSIDE_QUERY) {
+                assertFalse(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+                assertFalse(circle2D.intersectsLine(ax, ay, bx, by))
+                assertFalse(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+                assertFalse(circle2D.containsLine(ax, ay, bx, by))
+                assertEquals(
+                    Component2D.WithinRelation.DISJOINT,
+                    circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+                )
+            } else if (r == PointValues.Relation.CELL_INSIDE_QUERY) {
+                assertTrue(circle2D.intersectsTriangle(ax, ay, bx, by, cx, cy))
+                assertTrue(circle2D.intersectsLine(ax, ay, bx, by))
+                assertTrue(circle2D.containsTriangle(ax, ay, bx, by, cx, cy))
+                assertTrue(circle2D.containsLine(ax, ay, bx, by))
+                assertNotEquals(
+                    Component2D.WithinRelation.CANDIDATE,
+                    circle2D.withinTriangle(ax, ay, true, bx, by, true, cx, cy, true)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testLineIntersects() {
+        val circle2D = if (random().nextBoolean()) {
+            val circle = Circle(0.0, 0.0, 35000.0)
+            LatLonGeometry.create(circle)
+        } else {
+            val xyCircle = XYCircle(0f, 0f, 0.3f)
+            XYGeometry.create(xyCircle)
+        }
+        val ax = -0.25
+        val ay = 0.25
+        val bx = 0.25
+        val by = 0.25
+        val cx = 0.2
+        val cy = 0.25
+        assertTrue(circle2D.intersectsLine(ax, ay, bx, by))
+        assertFalse(circle2D.intersectsLine(bx, by, cx, cy))
+        assertFalse(circle2D.intersectsLine(cx, cy, bx, by))
+    }
+}

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/GeoTestUtil.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/GeoTestUtil.kt
@@ -1,6 +1,9 @@
 package org.gnit.lucenekmp.tests.geo
 
 import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.geo.Circle
+import org.gnit.lucenekmp.geo.GeoUtils
+import kotlin.math.PI
 
 object GeoTestUtil {
     private const val MIN_LAT_INCL: Double = -90.0
@@ -14,5 +17,12 @@ object GeoTestUtil {
 
     fun nextLongitude(): Double {
         return MIN_LON_INCL + (MAX_LON_INCL - MIN_LON_INCL) * LuceneTestCase.random().nextDouble()
+    }
+
+    fun nextCircle(): Circle {
+        val lat = nextLatitude()
+        val lon = nextLongitude()
+        val radiusMeters = LuceneTestCase.random().nextDouble() * GeoUtils.EARTH_MEAN_RADIUS_METERS * PI / 2.0 + 1.0
+        return Circle(lat, lon, radiusMeters)
     }
 }

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/ShapeTestUtil.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/geo/ShapeTestUtil.kt
@@ -1,0 +1,23 @@
+package org.gnit.lucenekmp.tests.geo
+
+import org.gnit.lucenekmp.geo.XYCircle
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.random.Random
+
+object ShapeTestUtil {
+    private fun nextFloat(random: Random): Float {
+        val sign = if (random.nextBoolean()) 1f else -1f
+        return random.nextFloat() * Float.MAX_VALUE * sign
+    }
+
+    fun nextCircle(): XYCircle {
+        val random = LuceneTestCase.random()
+        val x = nextFloat(random)
+        val y = nextFloat(random)
+        var radius = 0f
+        while (radius == 0f) {
+            radius = random.nextFloat() * Float.MAX_VALUE / 2f
+        }
+        return XYCircle(x, y, radius)
+    }
+}


### PR DESCRIPTION
## Summary
- port lucene `TestCircle2D` to Kotlin
- add `nextCircle` helper to `GeoTestUtil`
- add new `ShapeTestUtil` for generating XY circles

## Testing
- `./gradlew jvmTest`
- `./gradlew linuxX64Test` *(fails: Build did not finish due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_684b9907c1b8832b9782a9555e15b64d