### PR TITLE
Add util.fst.TestUtil and NoOutputs

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/fst/FSTCompiler.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/fst/FSTCompiler.kt
@@ -1060,7 +1060,8 @@ class FSTCompiler<T> private constructor(
                         + numArcs)
             }
             if (numArcs == arcs.size) {
-                val newArcs: Array<Arc<T>> = ArrayUtil.grow(arcs)
+                @Suppress("UNCHECKED_CAST")
+                val newArcs = ArrayUtil.grow(arcs as Array<Arc<T>?>, arcs.size + 1) as Array<Arc<T>>
                 for (arcIdx in numArcs..<newArcs.size) {
                     newArcs[arcIdx] = Arc()
                 }

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/fst/NoOutputs.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/fst/NoOutputs.kt
@@ -1,0 +1,54 @@
+package org.gnit.lucenekmp.util.fst
+
+import org.gnit.lucenekmp.store.DataInput
+import org.gnit.lucenekmp.store.DataOutput
+
+/**
+ * A null FST [Outputs] implementation; use this if you just want to build an FSA.
+ */
+class NoOutputs private constructor() : Outputs<Any>() {
+    override fun common(output1: Any, output2: Any): Any {
+        require(output1 === NO_OUTPUT)
+        require(output2 === NO_OUTPUT)
+        return NO_OUTPUT
+    }
+
+    override fun subtract(output: Any, inc: Any): Any {
+        require(output === NO_OUTPUT)
+        require(inc === NO_OUTPUT)
+        return NO_OUTPUT
+    }
+
+    override fun add(prefix: Any, output: Any): Any {
+        require(prefix === NO_OUTPUT) { "got $prefix" }
+        require(output === NO_OUTPUT)
+        return NO_OUTPUT
+    }
+
+
+    override fun write(output: Any, out: DataOutput) {
+        // no-op
+    }
+
+    override fun read(`in`: DataInput): Any {
+        return NO_OUTPUT
+    }
+
+    override val noOutput: Any
+        get() = NO_OUTPUT
+
+    override fun outputToString(output: Any): String = ""
+
+    override fun ramBytesUsed(output: Any): Long = 0L
+
+    override fun toString(): String = "NoOutputs"
+
+    companion object {
+        val NO_OUTPUT: Any = object {
+            override fun hashCode(): Int = 42
+            override fun equals(other: Any?): Boolean = other === this
+        }
+
+        val singleton: NoOutputs = NoOutputs()
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/fst/TestUtil.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/fst/TestUtil.kt
@@ -1,0 +1,103 @@
+package org.gnit.lucenekmp.util.fst
+
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.util.BytesRef
+import org.gnit.lucenekmp.util.IntsRefBuilder
+import org.gnit.lucenekmp.util.fst.NoOutputs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TestUtil : LuceneTestCase() {
+
+    @Test
+    fun testBinarySearch() {
+        val letters = listOf("A", "E", "J", "K", "L", "O", "T", "z")
+        val fst = buildFST(letters, allowArrayArcs = true, allowDirectAddressing = false)
+        var arc = fst.getFirstArc(FST.Arc<Any>())
+        arc = fst.readFirstTargetArc(arc, arc, fst.getBytesReader())
+        for (i in letters.indices) {
+            assertEquals(i, Util.binarySearch(fst, arc, letters[i][0].code))
+        }
+        assertEquals(-1, Util.binarySearch(fst, arc, ' '.code))
+        assertEquals(-1 - letters.size, Util.binarySearch(fst, arc, '~'.code))
+        assertEquals(-2, Util.binarySearch(fst, arc, 'B'.code))
+        assertEquals(-2, Util.binarySearch(fst, arc, 'C'.code))
+        assertEquals(-7, Util.binarySearch(fst, arc, 'P'.code))
+    }
+
+    @Test
+    fun testContinuous() {
+        val letters = listOf("A", "B", "C", "D", "E", "F", "G", "H")
+        val fst = buildFST(letters, allowArrayArcs = true, allowDirectAddressing = false)
+        val first = fst.getFirstArc(FST.Arc<Any>())
+        var arc = FST.Arc<Any>()
+        val input = fst.getBytesReader()
+        for (letter in letters) {
+            val c = letter[0]
+            arc = Util.readCeilArc(c.code, fst, first, arc, input)!!
+            assertEquals(c.code, arc.label())
+        }
+        assertEquals('F'.code, Util.readCeilArc('F'.code, fst, first, arc, input)!!.label())
+        assertNull(Util.readCeilArc('A'.code, fst, arc, arc, input))
+    }
+
+    @Test
+    fun testReadCeilArcPackedArray() {
+        val letters = listOf("A", "E", "J", "K", "L", "O", "T", "z")
+        verifyReadCeilArc(letters, allowArrayArcs = true, allowDirectAddressing = false)
+    }
+
+    @Test
+    fun testReadCeilArcArrayWithGaps() {
+        val letters = listOf("A", "E", "J", "K", "L", "O", "T")
+        verifyReadCeilArc(letters, allowArrayArcs = true, allowDirectAddressing = true)
+    }
+
+    @Test
+    fun testReadCeilArcList() {
+        val letters = listOf("A", "E", "J", "K", "L", "O", "T", "z")
+        verifyReadCeilArc(letters, allowArrayArcs = false, allowDirectAddressing = false)
+    }
+
+    private fun verifyReadCeilArc(
+        letters: List<String>,
+        allowArrayArcs: Boolean,
+        allowDirectAddressing: Boolean
+    ) {
+        val fst = buildFST(letters, allowArrayArcs, allowDirectAddressing)
+        val first = fst.getFirstArc(FST.Arc<Any>())
+        var arc = FST.Arc<Any>()
+        val input = fst.getBytesReader()
+        for (letter in letters) {
+            val c = letter[0]
+            arc = Util.readCeilArc(c.code, fst, first, arc, input)!!
+            assertEquals(c.code, arc.label())
+        }
+        assertEquals('A'.code, Util.readCeilArc(' '.code, fst, first, arc, input)!!.label())
+        assertNull(Util.readCeilArc('~'.code, fst, first, arc, input))
+        assertEquals('J'.code, Util.readCeilArc('F'.code, fst, first, arc, input)!!.label())
+        assertNull(Util.readCeilArc('Z'.code, fst, arc, arc, input))
+    }
+
+    private fun buildFST(
+        words: List<String>,
+        allowArrayArcs: Boolean,
+        allowDirectAddressing: Boolean
+    ): FST<Any> {
+        val outputs = NoOutputs.singleton
+        val builder = FSTCompiler.Builder(FST.INPUT_TYPE.BYTE1, outputs)
+            .allowFixedLengthArcs(allowArrayArcs)
+        if (!allowDirectAddressing) {
+            builder.directAddressingMaxOversizingFactor(-1f)
+        }
+        val fstCompiler = builder.build()
+        for (word in words) {
+            fstCompiler.add(
+                Util.toIntsRef(BytesRef(word), IntsRefBuilder()),
+                outputs.noOutput
+            )
+        }
+        return FST.fromFSTReader(fstCompiler.compile(), fstCompiler.getFSTReader())!!
+    }
+}


### PR DESCRIPTION
## Summary
- port Lucene fst/TestUtil to Kotlin tests
- add NoOutputs implementation for FST
- fix FSTCompiler growth of arc arrays
- move FST TestUtil to commonTest so it runs on all platforms

## Testing
- `./gradlew jvmTest --tests "*TestUtil*"`
- `./gradlew linuxX64Test --tests "*TestUtil*"`

------
https://chatgpt.com/codex/tasks/task_e_684b96e56994832b9f4895b10841caca