### PR TITLE
Port TestFilterDirectory

### DIFF
--- a/core/src/jvmTest/kotlin/org/gnit/lucenekmp/store/TestFilterDirectory.kt
+++ b/core/src/jvmTest/kotlin/org/gnit/lucenekmp/store/TestFilterDirectory.kt
@@ -1,0 +1,44 @@
+package org.gnit.lucenekmp.store
+
+import okio.Path
+import org.gnit.lucenekmp.tests.store.BaseDirectoryTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import java.lang.reflect.Method
+
+class TestFilterDirectory : BaseDirectoryTestCase() {
+    override fun getDirectory(path: Path): Directory {
+        return object : FilterDirectory(FSDirectory.open(path)) {}
+    }
+
+    @Test
+    fun testOverrides() {
+        val exclude = HashSet<Method>()
+        exclude.add(
+            Directory::class.java.getMethod(
+                "copyFrom",
+                Directory::class.java,
+                String::class.java,
+                String::class.java,
+                IOContext::class.java
+            )
+        )
+        exclude.add(Directory::class.java.getMethod("openChecksumInput", String::class.java))
+        for (m in FilterDirectory::class.java.methods) {
+            if (m.declaringClass == Directory::class.java) {
+                assertTrue(exclude.contains(m), "method ${m.name} not overridden!")
+            }
+        }
+    }
+
+    @Test
+    fun testUnwrap() {
+        val dir = FSDirectory.open(createTempDir("unwrap"))
+        val dir2 = object : FilterDirectory(dir) {}
+        assertEquals(dir, dir2.`in`)
+        assertEquals(dir, FilterDirectory.unwrap(dir2))
+        dir2.close()
+    }
+}
+


### PR DESCRIPTION
## Summary
- port `TestFilterDirectory` from Apache Lucene
- create jvm test using `BaseDirectoryTestCase`

## Testing
- `./gradlew jvmTest --no-daemon --console=plain`
- `./gradlew linuxX64Test --no-daemon --console=plain --tests org.gnit.lucenekmp.store.TestFilterDirectory` *(fails: took too long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6851041dc134832b85e315655fe06e9b