### PR TITLE
Port MockAnalyzer to common tests

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/Analyzer.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/Analyzer.kt
@@ -272,7 +272,7 @@ abstract class Analyzer
      * @param fieldName IndexableField name being indexed.
      * @return position increment gap, added to the next token emitted from [     ][.tokenStream]. This value must be `>= 0`.
      */
-    fun getPositionIncrementGap(fieldName: String?): Int {
+    open fun getPositionIncrementGap(fieldName: String?): Int {
         return 0
     }
 
@@ -284,7 +284,7 @@ abstract class Analyzer
      * @return offset gap, added to the next token emitted from [.tokenStream].
      * This value must be `>= 0`.
      */
-    fun getOffsetGap(fieldName: String?): Int {
+    open fun getOffsetGap(fieldName: String?): Int {
         return 1
     }
 

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockAnalyzer.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockAnalyzer.kt
@@ -1,0 +1,99 @@
+package org.gnit.lucenekmp.tests.analysis
+
+import org.gnit.lucenekmp.analysis.Analyzer
+import org.gnit.lucenekmp.analysis.TokenFilter
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.TestUtil
+import org.gnit.lucenekmp.util.automaton.CharacterRunAutomaton
+import kotlin.random.Random
+
+/** Analyzer for testing purposes. */
+class MockAnalyzer(
+    random: Random,
+    private val runAutomaton: CharacterRunAutomaton,
+    private val lowerCase: Boolean,
+    private val filter: CharacterRunAutomaton
+) : Analyzer(PER_FIELD_REUSE_STRATEGY) {
+
+    private val random: Random = Random(random.nextLong())
+    private var positionIncrementGap: Int = 0
+    private var offsetGap: Int? = null
+    private val previousMappings = mutableMapOf<String, Int>()
+    private var enableChecks = true
+    private var maxTokenLength = MockTokenizer.DEFAULT_MAX_TOKEN_LENGTH
+
+    constructor(random: Random, runAutomaton: CharacterRunAutomaton, lowerCase: Boolean) :
+            this(random, runAutomaton, lowerCase, MockTokenFilter.EMPTY_STOPSET)
+
+    constructor(random: Random) : this(random, MockTokenizer.WHITESPACE, true)
+
+    override fun createComponents(fieldName: String): TokenStreamComponents {
+        val tokenizer = MockTokenizer(runAutomaton, lowerCase, maxTokenLength)
+        tokenizer.setEnableChecks(enableChecks)
+        val filt = MockTokenFilter(tokenizer, filter)
+        return TokenStreamComponents(tokenizer, maybePayload(filt, fieldName))
+    }
+
+    override fun normalize(fieldName: String, `in`: TokenStream): TokenStream {
+        var result: TokenStream = `in`
+        if (lowerCase) {
+            result = MockLowerCaseFilter(result)
+        }
+        return result
+    }
+
+    private fun maybePayload(stream: TokenFilter, fieldName: String): TokenFilter {
+        var valInt = previousMappings[fieldName]
+        if (valInt == null) {
+            var v = -1
+            if (TestUtil.rarely(random)) {
+                when (random.nextInt(3)) {
+                    0 -> v = -1
+                    1 -> v = Int.MAX_VALUE
+                    2 -> v = random.nextInt(12)
+                }
+            }
+            if (LuceneTestCase.VERBOSE) {
+                when (v) {
+                    Int.MAX_VALUE -> println("MockAnalyzer: field=$fieldName gets variable length payloads")
+                    -1 -> {}
+                    else -> println("MockAnalyzer: field=$fieldName gets fixed length=$v payloads")
+                }
+            }
+            previousMappings[fieldName] = v
+            valInt = v
+        }
+        return when (valInt) {
+            -1 -> stream
+            Int.MAX_VALUE -> MockVariableLengthPayloadFilter(random, stream)
+            else -> MockFixedLengthPayloadFilter(random, stream, valInt!!)
+        }
+    }
+
+    fun setPositionIncrementGap(gap: Int) {
+        this.positionIncrementGap = gap
+    }
+
+    override fun getPositionIncrementGap(fieldName: String?): Int {
+        return positionIncrementGap
+    }
+
+    fun setOffsetGap(gap: Int) {
+        this.offsetGap = gap
+    }
+
+    override fun getOffsetGap(fieldName: String?): Int {
+        return offsetGap ?: super.getOffsetGap(fieldName)
+    }
+
+    /** Toggle consumer workflow checking. */
+    fun setEnableChecks(enable: Boolean) {
+        this.enableChecks = enable
+    }
+
+    /** Toggle maxTokenLength for MockTokenizer */
+    fun setMaxTokenLength(length: Int) {
+        this.maxTokenLength = length
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockFixedLengthPayloadFilter.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockFixedLengthPayloadFilter.kt
@@ -1,0 +1,35 @@
+package org.gnit.lucenekmp.tests.analysis
+
+import okio.IOException
+import org.gnit.lucenekmp.analysis.TokenFilter
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.analysis.tokenattributes.PayloadAttribute
+import org.gnit.lucenekmp.util.BytesRef
+import kotlin.random.Random
+
+/** TokenFilter that adds random fixed-length payloads. */
+class MockFixedLengthPayloadFilter(
+    private val random: Random,
+    `in`: TokenStream,
+    length: Int
+) : TokenFilter(`in`) {
+    private val payloadAtt: PayloadAttribute = addAttribute(PayloadAttribute::class)
+    private val bytes: ByteArray
+    private val payload: BytesRef
+
+    init {
+        require(length >= 0) { "length must be >= 0" }
+        bytes = ByteArray(length)
+        payload = BytesRef(bytes)
+    }
+
+    @Throws(IOException::class)
+    override fun incrementToken(): Boolean {
+        if (input.incrementToken()) {
+            random.nextBytes(bytes)
+            payloadAtt.setPayload(payload)
+            return true
+        }
+        return false
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockLowerCaseFilter.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockLowerCaseFilter.kt
@@ -1,0 +1,21 @@
+package org.gnit.lucenekmp.tests.analysis
+
+import okio.IOException
+import org.gnit.lucenekmp.analysis.CharacterUtils
+import org.gnit.lucenekmp.analysis.TokenFilter
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.analysis.tokenattributes.CharTermAttribute
+
+/** A lowercasing [TokenFilter]. */
+class MockLowerCaseFilter(`in`: TokenStream) : TokenFilter(`in`) {
+    private val termAtt: CharTermAttribute = addAttribute(CharTermAttribute::class)
+
+    @Throws(IOException::class)
+    override fun incrementToken(): Boolean {
+        if (input.incrementToken()) {
+            CharacterUtils.toLowerCase(termAtt.buffer(), 0, termAtt.length)
+            return true
+        }
+        return false
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockTokenFilter.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockTokenFilter.kt
@@ -1,0 +1,99 @@
+package org.gnit.lucenekmp.tests.analysis
+
+import okio.IOException
+import org.gnit.lucenekmp.analysis.TokenFilter
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.analysis.tokenattributes.CharTermAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.PositionIncrementAttribute
+import org.gnit.lucenekmp.util.automaton.CharacterRunAutomaton
+import org.gnit.lucenekmp.util.automaton.Automata
+import org.gnit.lucenekmp.util.automaton.Operations
+
+/**
+ * A token filter for testing that removes terms accepted by a DFA.
+ */
+class MockTokenFilter(
+    input: TokenStream,
+    private val filter: CharacterRunAutomaton
+) : TokenFilter(input) {
+
+    companion object {
+        /** Empty set of stopwords */
+        val EMPTY_STOPSET = CharacterRunAutomaton(Automata.makeEmpty())
+
+        /** Set of common English stopwords */
+        val ENGLISH_STOPSET: CharacterRunAutomaton = CharacterRunAutomaton(
+            Operations.determinize(
+                Operations.union(
+                    mutableListOf(
+                        Automata.makeString("a"),
+                        Automata.makeString("an"),
+                        Automata.makeString("and"),
+                        Automata.makeString("are"),
+                        Automata.makeString("as"),
+                        Automata.makeString("at"),
+                        Automata.makeString("be"),
+                        Automata.makeString("but"),
+                        Automata.makeString("by"),
+                        Automata.makeString("for"),
+                        Automata.makeString("if"),
+                        Automata.makeString("in"),
+                        Automata.makeString("into"),
+                        Automata.makeString("is"),
+                        Automata.makeString("it"),
+                        Automata.makeString("no"),
+                        Automata.makeString("not"),
+                        Automata.makeString("of"),
+                        Automata.makeString("on"),
+                        Automata.makeString("or"),
+                        Automata.makeString("such"),
+                        Automata.makeString("that"),
+                        Automata.makeString("the"),
+                        Automata.makeString("their"),
+                        Automata.makeString("then"),
+                        Automata.makeString("there"),
+                        Automata.makeString("these"),
+                        Automata.makeString("they"),
+                        Automata.makeString("this"),
+                        Automata.makeString("to"),
+                        Automata.makeString("was"),
+                        Automata.makeString("will"),
+                        Automata.makeString("with")
+                    )
+                ),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            )
+        )
+    }
+
+    private val termAtt: CharTermAttribute = addAttribute(CharTermAttribute::class)
+    private val posIncrAtt: PositionIncrementAttribute =
+        addAttribute(PositionIncrementAttribute::class)
+
+    private var skippedPositions = 0
+
+    @Throws(IOException::class)
+    override fun incrementToken(): Boolean {
+        skippedPositions = 0
+        while (input.incrementToken()) {
+            if (!filter.run(termAtt.buffer(), 0, termAtt.length)) {
+                posIncrAtt.setPositionIncrement(posIncrAtt.getPositionIncrement() + skippedPositions)
+                return true
+            }
+            skippedPositions += posIncrAtt.getPositionIncrement()
+        }
+        return false
+    }
+
+    @Throws(IOException::class)
+    override fun end() {
+        super.end()
+        posIncrAtt.setPositionIncrement(posIncrAtt.getPositionIncrement() + skippedPositions)
+    }
+
+    @Throws(IOException::class)
+    override fun reset() {
+        super.reset()
+        skippedPositions = 0
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockTokenizer.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockTokenizer.kt
@@ -1,0 +1,274 @@
+package org.gnit.lucenekmp.tests.analysis
+
+import okio.IOException
+import org.gnit.lucenekmp.analysis.Tokenizer
+import org.gnit.lucenekmp.analysis.tokenattributes.CharTermAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.OffsetAttribute
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.util.AttributeFactory
+import org.gnit.lucenekmp.util.automaton.CharacterRunAutomaton
+import org.gnit.lucenekmp.util.automaton.Operations
+import org.gnit.lucenekmp.util.automaton.RegExp
+import org.gnit.lucenekmp.jdkport.Character
+import org.gnit.lucenekmp.jdkport.isHighSurrogate
+import org.gnit.lucenekmp.jdkport.isLowSurrogate
+import org.gnit.lucenekmp.jdkport.toCodePoint
+import kotlin.random.Random
+
+/**
+ * Tokenizer for testing.
+ *
+ * This tokenizer is a replacement for WHITESPACE, SIMPLE, and KEYWORD tokenizers.
+ * It provides extra checks useful for testing.
+ */
+class MockTokenizer : Tokenizer {
+    companion object {
+        /** Acts similar to WhitespaceTokenizer */
+        val WHITESPACE: CharacterRunAutomaton = CharacterRunAutomaton(
+            Operations.determinize(RegExp("[^ \t\r\n]+").toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+        )
+
+        /** Acts similar to KeywordTokenizer */
+        val KEYWORD: CharacterRunAutomaton = CharacterRunAutomaton(
+            Operations.determinize(RegExp(".*").toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+        )
+
+        /** Acts like LetterTokenizer (partial Unicode [:Letter:]) */
+        val SIMPLE: CharacterRunAutomaton = CharacterRunAutomaton(
+            Operations.determinize(
+                RegExp("[A-Za-zªµºÀ-ÖØ-öø-ˁ一-鿌]+").toAutomaton(),
+                Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+            )
+        )
+
+        /** Limit the default token length. */
+        const val DEFAULT_MAX_TOKEN_LENGTH = 255
+    }
+
+    private val runAutomaton: CharacterRunAutomaton
+    private val lowerCase: Boolean
+    private val maxTokenLength: Int
+    private var state = 0
+
+    private val termAtt = addAttribute(CharTermAttribute::class)
+    private val offsetAtt = addAttribute(OffsetAttribute::class)
+    private var off = 0
+
+    private var bufferedCodePoint = -1
+    private var bufferedOff = -1
+
+    private enum class State { SETREADER, RESET, INCREMENT, INCREMENT_FALSE, END, CLOSE }
+    private var streamState = State.CLOSE
+    private var lastOffset = 0
+    private var enableChecks = true
+
+    private val random = Random(LuceneTestCase.random().nextLong())
+
+    constructor(
+        factory: AttributeFactory,
+        runAutomaton: CharacterRunAutomaton,
+        lowerCase: Boolean,
+        maxTokenLength: Int = DEFAULT_MAX_TOKEN_LENGTH
+    ) : super(factory) {
+        this.runAutomaton = runAutomaton
+        this.lowerCase = lowerCase
+        this.maxTokenLength = maxTokenLength
+    }
+
+    constructor(
+        runAutomaton: CharacterRunAutomaton,
+        lowerCase: Boolean,
+        maxTokenLength: Int = DEFAULT_MAX_TOKEN_LENGTH
+    ) : super() {
+        this.runAutomaton = runAutomaton
+        this.lowerCase = lowerCase
+        this.maxTokenLength = maxTokenLength
+    }
+
+    constructor() : this(WHITESPACE, true)
+
+    constructor(factory: AttributeFactory) : this(factory, WHITESPACE, true)
+
+    private fun fail(message: String) {
+        if (enableChecks) {
+            throw IllegalStateException(message)
+        }
+    }
+
+    private fun failAlways(message: String): Nothing {
+        throw IllegalStateException(message)
+    }
+
+    @Throws(IOException::class)
+    override fun incrementToken(): Boolean {
+        if (streamState != State.RESET && streamState != State.INCREMENT) {
+            fail("incrementToken() called while in wrong state: $streamState")
+        }
+        clearAttributes()
+        while (true) {
+            val startOffset: Int
+            var cp: Int
+            if (bufferedCodePoint >= 0) {
+                cp = bufferedCodePoint
+                startOffset = bufferedOff
+                bufferedCodePoint = -1
+            } else {
+                startOffset = off
+                cp = readCodePoint()
+            }
+            if (cp < 0) {
+                break
+            } else if (isTokenChar(cp)) {
+                val chars = CharArray(2)
+                var endOffset: Int
+                do {
+                    val len = Character.toChars(normalize(cp), chars, 0)
+                    for (i in 0 until len) {
+                        termAtt.append(chars[i])
+                    }
+                    endOffset = off
+                    if (termAtt.length >= maxTokenLength) {
+                        break
+                    }
+                    cp = readCodePoint()
+                } while (cp >= 0 && isTokenChar(cp))
+
+                if (termAtt.length < maxTokenLength) {
+                    bufferedCodePoint = cp
+                    bufferedOff = endOffset
+                } else {
+                    bufferedCodePoint = -1
+                }
+                val correctedStartOffset = correctOffset(startOffset)
+                val correctedEndOffset = correctOffset(endOffset)
+                if (correctedStartOffset < 0) {
+                    failAlways("invalid start offset: $correctedStartOffset, before correction: $startOffset")
+                }
+                if (correctedEndOffset < 0) {
+                    failAlways("invalid end offset: $correctedEndOffset, before correction: $endOffset")
+                }
+                if (correctedStartOffset < lastOffset) {
+                    failAlways("start offset went backwards: $correctedStartOffset, before correction: $startOffset, lastOffset: $lastOffset")
+                }
+                lastOffset = correctedStartOffset
+                if (correctedEndOffset < correctedStartOffset) {
+                    failAlways("end offset: $correctedEndOffset is before start offset: $correctedStartOffset")
+                }
+                offsetAtt.setOffset(correctedStartOffset, correctedEndOffset)
+                if (state == -1 || runAutomaton.isAccept(state)) {
+                    streamState = State.INCREMENT
+                    return true
+                }
+            }
+        }
+        streamState = State.INCREMENT_FALSE
+        return false
+    }
+
+    @Throws(IOException::class)
+    protected open fun readCodePoint(): Int {
+        val ch = readChar()
+        return if (ch < 0) {
+            ch
+        } else {
+            if (ch.toChar().isLowSurrogate()) {
+                failAlways("unpaired low surrogate: ${ch.toString(16)}")
+            }
+            off++
+            if (ch.toChar().isHighSurrogate()) {
+                val ch2 = readChar()
+                if (ch2 >= 0) {
+                    off++
+                    if (!ch2.toChar().isLowSurrogate()) {
+                        failAlways(
+                            "unpaired high surrogate: ${ch.toString(16)}, followed by: ${ch2.toString(16)}"
+                        )
+                    }
+                    return toCodePoint(ch.toChar(), ch2.toChar())
+                } else {
+                    failAlways("stream ends with unpaired high surrogate: ${ch.toString(16)}")
+                }
+            }
+            ch
+        }
+    }
+
+    @Throws(IOException::class)
+    protected open fun readChar(): Int {
+        return when (random.nextInt(10)) {
+            0 -> {
+                val c = CharArray(1)
+                val ret = input.read(c, 0, 1)
+                if (ret < 0) ret else c[0].code
+            }
+            1 -> {
+                val c = CharArray(2)
+                val ret = input.read(c, 1, 1)
+                if (ret < 0) ret else c[1].code
+            }
+            2 -> {
+                val c = CharArray(1)
+                val cb = org.gnit.lucenekmp.jdkport.CharBuffer.wrap(c)
+                val ret = input.read(cb)
+                if (ret < 0) ret else c[0].code
+            }
+            else -> input.read()
+        }
+    }
+
+    protected open fun isTokenChar(c: Int): Boolean {
+        if (state < 0) {
+            state = 0
+        }
+        state = runAutomaton.step(state, c)
+        return state >= 0
+    }
+
+    protected open fun normalize(c: Int): Int = if (lowerCase) Character.toLowerCase(c) else c
+
+    @Throws(IOException::class)
+    override fun reset() {
+        try {
+            super.reset()
+            state = 0
+            lastOffset = 0
+            off = 0
+            bufferedCodePoint = -1
+            if (streamState == State.RESET) {
+                fail("double reset()")
+            }
+        } finally {
+            streamState = State.RESET
+        }
+    }
+
+    override fun close() {
+        try {
+            super.close()
+            if (streamState != State.END && streamState != State.CLOSE) {
+                fail("close() called in wrong state: $streamState")
+            }
+        } finally {
+            streamState = State.CLOSE
+        }
+    }
+
+    override fun end() {
+        try {
+            super.end()
+            val finalOffset = correctOffset(off)
+            offsetAtt.setOffset(finalOffset, finalOffset)
+            if (streamState != State.INCREMENT_FALSE) {
+                fail("end() called in wrong state=$streamState!")
+            }
+        } finally {
+            streamState = State.END
+        }
+    }
+
+
+    /** Toggle consumer workflow checking */
+    fun setEnableChecks(enable: Boolean) {
+        this.enableChecks = enable
+    }
+}

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockVariableLengthPayloadFilter.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/tests/analysis/MockVariableLengthPayloadFilter.kt
@@ -1,0 +1,33 @@
+package org.gnit.lucenekmp.tests.analysis
+
+import okio.IOException
+import org.gnit.lucenekmp.analysis.TokenFilter
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.analysis.tokenattributes.PayloadAttribute
+import org.gnit.lucenekmp.util.BytesRef
+import kotlin.random.Random
+
+/** TokenFilter that adds random variable-length payloads. */
+class MockVariableLengthPayloadFilter(
+    private val random: Random,
+    `in`: TokenStream
+) : TokenFilter(`in`) {
+    companion object {
+        private const val MAXLENGTH = 129
+    }
+
+    private val payloadAtt: PayloadAttribute = addAttribute(PayloadAttribute::class)
+    private val bytes = ByteArray(MAXLENGTH)
+    private val payload = BytesRef(bytes)
+
+    @Throws(IOException::class)
+    override fun incrementToken(): Boolean {
+        if (input.incrementToken()) {
+            random.nextBytes(bytes)
+            payload.length = random.nextInt(MAXLENGTH)
+            payloadAtt.setPayload(payload)
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Summary
- port Lucene MockAnalyzer and related helpers to Kotlin common tests
- expose Analyzer gaps as overridable
- remove outdated Java test helpers

## Testing
- `./gradlew jvmTest --info --no-daemon`
- `./gradlew linuxX64Test --info --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6856975e28ec832bb40eed5ade193d29