### PR TITLE
[WIP] Port MockDirectoryWrapper (1145LOC, Depends on CheckIndex Port)

### DIFF
--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/store/BaseDirectoryWrapper.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/store/BaseDirectoryWrapper.kt
@@ -1,0 +1,37 @@
+package org.gnit.lucenekmp.tests.store
+
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.store.FilterDirectory
+
+/**
+ * Minimal port of Lucene's BaseDirectoryWrapper.
+ * Only provides basic tracking of open state and a toggle for
+ * running checkIndex on close. The actual checkIndex logic is not
+ * implemented yet.
+ */
+open class BaseDirectoryWrapper(
+    /** Wrapped directory instance. */
+    delegate: Directory
+) : FilterDirectory(delegate) {
+
+    /** whether this directory is still open */
+    private var _isOpen: Boolean = true
+
+    /** whether checkIndex should run on close */
+    var checkIndexOnClose: Boolean = true
+
+    /** level passed to checkIndex when closing */
+    var levelForCheckOnClose: Int = 0
+
+    override fun close() {
+        if (_isOpen) {
+            _isOpen = false
+            // TODO: implement checkIndex when CheckIndex is ported
+        }
+        super.close()
+    }
+
+    /** Returns true if this directory has not been closed. */
+    fun isOpen(): Boolean = _isOpen
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/store/MockDirectoryWrapper.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/store/MockDirectoryWrapper.kt
@@ -1,0 +1,47 @@
+package org.gnit.lucenekmp.tests.store
+
+import okio.IOException
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.store.IOContext
+import org.gnit.lucenekmp.store.IndexInput
+import org.gnit.lucenekmp.store.IndexOutput
+import kotlin.random.Random
+
+/**
+ * Lightweight Kotlin port of Lucene's MockDirectoryWrapper.
+ *
+ * This implementation only contains a very small subset of the
+ * original functionality which is sufficient for the current
+ * test-framework. Features such as crash simulation, file handle
+ * tracking and Windows specific behaviour are currently not implemented.
+ */
+class MockDirectoryWrapper(
+    private val random: Random,
+    delegate: Directory
+) : BaseDirectoryWrapper(delegate) {
+
+    /** Probability of throwing an IOException during write operations. */
+    var randomIOExceptionRate: Double = 0.0
+
+    /** Probability of throwing an IOException when opening files. */
+    var randomIOExceptionRateOnOpen: Double = 0.0
+
+    private fun maybeThrowIOException(reason: String?) {
+        if (random.nextDouble() < randomIOExceptionRate) {
+            throw IOException("Mock IO exception" + (reason?.let { ": $it" } ?: ""))
+        }
+    }
+
+    override fun createOutput(name: String, context: IOContext): IndexOutput {
+        maybeThrowIOException(name)
+        return super.createOutput(name, context)
+    }
+
+    override fun openInput(name: String, context: IOContext): IndexInput {
+        if (random.nextDouble() < randomIOExceptionRateOnOpen) {
+            throw IOException("Mock IO exception opening $name")
+        }
+        return super.openInput(name, context)
+    }
+}
+


### PR DESCRIPTION
## Summary
- port MockDirectoryWrapper from Lucene as a simplified Kotlin version
- add its base class `BaseDirectoryWrapper`
- provide basic random I/O failure functionality

## Testing
- `./gradlew test-framework:jvmTest --console plain --no-daemon`
- `./gradlew test-framework:linuxX64Test --console plain --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68569a79ebfc832b96a1e6a0b02f453f