### PR TITLE
Port TestDateTools to Kotlin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
     name: Full Build and Test
     needs: [build-jvm, build-android, build-ios]
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
       - name: Checkout code

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,10 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import kotlin.apply
+import java.util.concurrent.TimeUnit
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -127,32 +132,100 @@ val enableHangDetection = providers
     .map { it.equals("true", ignoreCase = true) }
     .orElse(false)
 
+// --- Low-noise, precise hang detection for tests (JVM/Android) ---
 tasks.withType<Test>().configureEach {
+    // Keep Gradle output short; rely on our custom listener for hangs/slow tests.
     testLogging {
-        events("started", "passed", "skipped", "failed")
-        showStandardStreams = true
+        // Only show failures from Gradle itself.
+        events("failed"/*, "skipped"*/)
+        showStandardStreams = false
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
     }
 
-    if(enableHangDetection.get()) {
-        val slowThresholdMs = 60_000L // 60 seconds; adjust as needed
+    if (enableHangDetection.get()) {
+        val slowThresholdMs = 60_000L // adjust as needed
+
+        // One scheduled, daemon thread per Test task
+        val scheduler = Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "hang-detector-tests").apply { isDaemon = true }
+        }
+
+        // Track delayed "potential hang" prints per test so we can cancel them on finish
+        val pending: MutableMap<String, ScheduledFuture<*>> = ConcurrentHashMap()
+
         addTestListener(object : TestListener {
             override fun beforeTest(descriptor: TestDescriptor) {
-                // to detect hanging tests
-                println("START ${descriptor.className} > ${descriptor.displayName}")
+                val id = "${descriptor.className} > ${descriptor.displayName}"
+                // Schedule a one-time "potential hang" message if it runs longer than threshold
+                val future = scheduler.schedule({
+                    println("POTENTIAL HANG TEST ($slowThresholdMs ms threshold) $id")
+                }, slowThresholdMs, TimeUnit.MILLISECONDS)
+                pending[id] = future
             }
 
             override fun afterTest(descriptor: TestDescriptor, result: TestResult) {
+                val id = "${descriptor.className} > ${descriptor.displayName}"
+                // Cancel the pending "hang" message if the test finished
+                pending.remove(id)?.cancel(false)
+
                 val dur = result.endTime - result.startTime
                 if (dur >= slowThresholdMs) {
-
-                    // to detect slow tests which passed or failed
-                    println("SLOW (${dur} ms) ${descriptor.className} > ${descriptor.displayName}")
+                    println("SLOW TEST (${dur} ms) $id")
                 }
             }
 
             override fun beforeSuite(suite: TestDescriptor) {}
             override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
         })
+
+        // Ensure the scheduler stops when the task finishes
+        this.doLast { scheduler.shutdownNow() }
+    }
+}
+
+// --- Low-noise, precise hang detection for Gradle tasks ---
+if (enableHangDetection.get()) {
+    val slowTaskThresholdMs = 120_000L // adjust as needed
+
+    val scheduler = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "hang-detector-tasks").apply { isDaemon = true }
+    }
+    val taskStart: MutableMap<String, Long> = ConcurrentHashMap()
+    val taskHangFuture: MutableMap<String, ScheduledFuture<*>> = ConcurrentHashMap()
+
+    gradle.addListener(object : TaskExecutionListener {
+        override fun beforeExecute(task: Task) {
+            val key = task.path
+            taskStart[key] = System.currentTimeMillis()
+            //println("START TASK $key")
+
+            // Schedule a one-time "potential hang" message
+            val future = scheduler.schedule({
+                println("POTENTIAL HANG TASK ($slowTaskThresholdMs ms threshold) $key")
+            }, slowTaskThresholdMs, TimeUnit.MILLISECONDS)
+            taskHangFuture[key] = future
+        }
+
+        override fun afterExecute(task: Task, state: TaskState) {
+            val key = task.path
+            taskHangFuture.remove(key)?.cancel(false)
+
+            val start = taskStart.remove(key) ?: return
+            val dur = System.currentTimeMillis() - start
+
+            if (dur >= slowTaskThresholdMs || state.failure != null) {
+                val status = when {
+                    state.failure != null -> "FAILED"
+                    state.skipped -> "SKIPPED"
+                    else -> "DONE"
+                }
+                println("SLOW TASK (${dur} ms) $key [$status]")
+            }
+        }
+    })
+
+    gradle.buildFinished {
+        scheduler.shutdownNow()
     }
 }
 

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/codecs/TestCodecUtil.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/codecs/TestCodecUtil.kt
@@ -1,0 +1,374 @@
+package org.gnit.lucenekmp.codecs
+
+import org.gnit.lucenekmp.index.CorruptIndexException
+import org.gnit.lucenekmp.store.BufferedChecksumIndexInput
+import org.gnit.lucenekmp.store.ByteBuffersDataOutput
+import org.gnit.lucenekmp.store.ByteBuffersIndexInput
+import org.gnit.lucenekmp.store.ByteBuffersIndexOutput
+import org.gnit.lucenekmp.store.ByteBuffersDirectory
+import org.gnit.lucenekmp.store.IOContext
+import org.gnit.lucenekmp.store.IndexInput
+import org.gnit.lucenekmp.store.IndexOutput
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.util.StringHelper
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** tests for codecutil methods */
+class TestCodecUtil : LuceneTestCase() {
+    @Test
+    fun testHeaderLength() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeHeader(output, "FooBar", 5)
+        output.writeString("this is the data")
+        output.close()
+
+        val input = ByteBuffersIndexInput(out.toDataInput(), "temp")
+        input.seek(CodecUtil.headerLength("FooBar").toLong())
+        assertEquals("this is the data", input.readString())
+        input.close()
+    }
+
+    @Test
+    fun testWriteTooLongHeader() {
+        val tooLong = StringBuilder()
+        for (i in 0 until 128) {
+            tooLong.append('a')
+        }
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        expectThrows(IllegalArgumentException::class) {
+            CodecUtil.writeHeader(output, tooLong.toString(), 5)
+        }
+    }
+
+    @Test
+    fun testWriteNonAsciiHeader() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        expectThrows(IllegalArgumentException::class) {
+            CodecUtil.writeHeader(output, "\u1234", 5)
+        }
+    }
+
+    @Test
+    fun testReadHeaderWrongMagic() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        output.writeInt(1234)
+        output.close()
+
+        val input = ByteBuffersIndexInput(out.toDataInput(), "temp")
+        expectThrows(CorruptIndexException::class) {
+            CodecUtil.checkHeader(input, "bogus", 1, 1)
+        }
+    }
+
+    @Test
+    fun testChecksumEntireFile() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeHeader(output, "FooBar", 5)
+        output.writeString("this is the data")
+        CodecUtil.writeFooter(output)
+        output.close()
+
+        val input = ByteBuffersIndexInput(out.toDataInput(), "temp")
+        CodecUtil.checksumEntireFile(input)
+        input.close()
+    }
+
+    @Test
+    fun testCheckFooterValid() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeHeader(output, "FooBar", 5)
+        output.writeString("this is the data")
+        CodecUtil.writeFooter(output)
+        output.close()
+
+        val input = BufferedChecksumIndexInput(ByteBuffersIndexInput(out.toDataInput(), "temp"))
+        val mine = RuntimeException("fake exception")
+        val expected = expectThrows(RuntimeException::class) {
+            CodecUtil.checkFooter(input, mine)
+        }
+        assertEquals("fake exception", expected!!.message)
+        val suppressed = expected.suppressedExceptions
+        assertEquals(1, suppressed.size)
+        assertTrue(suppressed[0].message!!.contains("checksum passed"))
+        input.close()
+    }
+
+    @Test
+    fun testCheckFooterValidAtFooter() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeHeader(output, "FooBar", 5)
+        output.writeString("this is the data")
+        CodecUtil.writeFooter(output)
+        output.close()
+
+        val input = BufferedChecksumIndexInput(ByteBuffersIndexInput(out.toDataInput(), "temp"))
+        CodecUtil.checkHeader(input, "FooBar", 5, 5)
+        assertEquals("this is the data", input.readString())
+        val mine = RuntimeException("fake exception")
+        val expected = expectThrows(RuntimeException::class) {
+            CodecUtil.checkFooter(input, mine)
+        }
+        assertEquals("fake exception", expected!!.message)
+        val suppressed = expected.suppressedExceptions
+        assertEquals(1, suppressed.size)
+        assertTrue(suppressed[0].message!!.contains("checksum passed"))
+        input.close()
+    }
+
+    @Test
+    fun testCheckFooterValidPastFooter() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeHeader(output, "FooBar", 5)
+        output.writeString("this is the data")
+        CodecUtil.writeFooter(output)
+        output.close()
+
+        val input = BufferedChecksumIndexInput(ByteBuffersIndexInput(out.toDataInput(), "temp"))
+        CodecUtil.checkHeader(input, "FooBar", 5, 5)
+        assertEquals("this is the data", input.readString())
+        input.readByte()
+        val mine = RuntimeException("fake exception")
+        val expected = expectThrows(CorruptIndexException::class) {
+            CodecUtil.checkFooter(input, mine)
+        }
+        assertTrue(expected!!.message!!.contains("checksum status indeterminate"))
+        val suppressed = expected.suppressedExceptions
+        assertEquals(1, suppressed.size)
+        assertEquals("fake exception", suppressed[0].message)
+        input.close()
+    }
+
+    @Test
+    fun testCheckFooterInvalid() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeHeader(output, "FooBar", 5)
+        output.writeString("this is the data")
+        CodecUtil.writeBEInt(output, CodecUtil.FOOTER_MAGIC)
+        CodecUtil.writeBEInt(output, 0)
+        CodecUtil.writeBELong(output, 1234567)
+        output.close()
+
+        val input = BufferedChecksumIndexInput(ByteBuffersIndexInput(out.toDataInput(), "temp"))
+        CodecUtil.checkHeader(input, "FooBar", 5, 5)
+        assertEquals("this is the data", input.readString())
+        val mine = RuntimeException("fake exception")
+        val expected = expectThrows(CorruptIndexException::class) {
+            CodecUtil.checkFooter(input, mine)
+        }
+        assertTrue(expected!!.message!!.contains("checksum failed"))
+        val suppressed = expected.suppressedExceptions
+        assertEquals(1, suppressed.size)
+        assertEquals("fake exception", suppressed[0].message)
+        input.close()
+    }
+
+    @Test
+    fun testSegmentHeaderLength() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeIndexHeader(output, "FooBar", 5, StringHelper.randomId(), "xyz")
+        output.writeString("this is the data")
+        output.close()
+
+        val input = ByteBuffersIndexInput(out.toDataInput(), "temp")
+        input.seek(CodecUtil.indexHeaderLength("FooBar", "xyz").toLong())
+        assertEquals("this is the data", input.readString())
+        input.close()
+    }
+
+    @Test
+    fun testWriteTooLongSuffix() {
+        val tooLong = StringBuilder()
+        for (i in 0 until 256) {
+            tooLong.append('a')
+        }
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        expectThrows(IllegalArgumentException::class) {
+            CodecUtil.writeIndexHeader(output, "foobar", 5, StringHelper.randomId(), tooLong.toString())
+        }
+    }
+
+    @Test
+    fun testWriteVeryLongSuffix() {
+        val justLongEnough = StringBuilder()
+        for (i in 0 until 255) {
+            justLongEnough.append('a')
+        }
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        val id = StringHelper.randomId()
+        CodecUtil.writeIndexHeader(output, "foobar", 5, id, justLongEnough.toString())
+        output.close()
+
+        val input = ByteBuffersIndexInput(out.toDataInput(), "temp")
+        CodecUtil.checkIndexHeader(input, "foobar", 5, 5, id, justLongEnough.toString())
+        assertEquals(input.filePointer, input.length())
+        assertEquals(input.filePointer, CodecUtil.indexHeaderLength("foobar", justLongEnough.toString()).toLong())
+        input.close()
+    }
+
+    @Test
+    fun testWriteNonAsciiSuffix() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        expectThrows(IllegalArgumentException::class) {
+            CodecUtil.writeIndexHeader(output, "foobar", 5, StringHelper.randomId(), "\u1234")
+        }
+    }
+
+    @Test
+    fun testReadBogusCRC() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        CodecUtil.writeBELong(output, -1L)
+        CodecUtil.writeBELong(output, 1L shl 32)
+        CodecUtil.writeBELong(output, -(1L shl 32))
+        CodecUtil.writeBELong(output, (1L shl 32) - 1)
+        output.close()
+        val input: IndexInput = BufferedChecksumIndexInput(ByteBuffersIndexInput(out.toDataInput(), "temp"))
+        for (i in 0 until 3) {
+            expectThrows(CorruptIndexException::class) {
+                CodecUtil.readCRC(input)
+            }
+        }
+        CodecUtil.readCRC(input)
+    }
+
+    @OptIn(ExperimentalAtomicApi::class)
+    @Test
+    fun testWriteBogusCRC() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        val fakeChecksum = AtomicLong(0)
+        val fakeOutput = object : IndexOutput("fake", "fake") {
+            override fun close() {
+                output.close()
+            }
+
+            override val filePointer: Long
+                get() = output.filePointer
+
+            override fun getChecksum(): Long {
+                return fakeChecksum.load()
+            }
+
+            override fun writeByte(b: Byte) {
+                output.writeByte(b)
+            }
+
+            override fun writeBytes(b: ByteArray, offset: Int, length: Int) {
+                output.writeBytes(b, offset, length)
+            }
+        }
+
+        fakeChecksum.store(-1L)
+        expectThrows(IllegalStateException::class) {
+            CodecUtil.writeCRC(fakeOutput)
+        }
+
+        fakeChecksum.store(1L shl 32)
+        expectThrows(IllegalStateException::class) {
+            CodecUtil.writeCRC(fakeOutput)
+        }
+
+        fakeChecksum.store(-(1L shl 32))
+        expectThrows(IllegalStateException::class) {
+            CodecUtil.writeCRC(fakeOutput)
+        }
+
+        fakeChecksum.store((1L shl 32) - 1)
+        CodecUtil.writeCRC(fakeOutput)
+    }
+
+    @Test
+    fun testTruncatedFileThrowsCorruptIndexException() {
+        val out = ByteBuffersDataOutput()
+        val output = ByteBuffersIndexOutput(out, "temp", "temp")
+        output.close()
+
+        val input = ByteBuffersIndexInput(out.toDataInput(), "temp")
+
+        var e = expectThrows(CorruptIndexException::class) {
+            CodecUtil.checksumEntireFile(input)
+        }
+        assertTrue(
+            e!!.message!!.contains(
+                "misplaced codec footer (file truncated?): length=0 but footerLength==16"
+            )
+        )
+
+        e = expectThrows(CorruptIndexException::class) {
+            CodecUtil.retrieveChecksum(input)
+        }
+        assertTrue(
+            e!!.message!!.contains(
+                "misplaced codec footer (file truncated?): length=0 but footerLength==16"
+            )
+        )
+    }
+
+    @Test
+    fun testRetrieveChecksum() {
+        val dir: Directory = ByteBuffersDirectory()
+        dir.createOutput("foo", IOContext.DEFAULT).use { out ->
+            out.writeByte(42)
+            CodecUtil.writeFooter(out)
+        }
+        dir.openInput("foo", IOContext.DEFAULT).use { `in` ->
+            CodecUtil.retrieveChecksum(`in`, `in`.length())
+
+            var exception = expectThrows(CorruptIndexException::class) {
+                CodecUtil.retrieveChecksum(`in`, `in`.length() - 1)
+            }
+            assertTrue(exception!!.message!!.contains("too long"))
+            assertEquals(0, exception.suppressedExceptions.size)
+
+            exception = expectThrows(CorruptIndexException::class) {
+                CodecUtil.retrieveChecksum(`in`, `in`.length() + 1)
+            }
+            assertTrue(exception!!.message!!.contains("truncated"))
+            assertEquals(0, exception.suppressedExceptions.size)
+        }
+
+        dir.createOutput("bar", IOContext.DEFAULT).use { out ->
+            for (i in 0..CodecUtil.footerLength()) {
+                out.writeByte(i.toByte())
+            }
+        }
+        dir.openInput("bar", IOContext.DEFAULT).use { `in` ->
+            var exception = expectThrows(CorruptIndexException::class) {
+                CodecUtil.retrieveChecksum(`in`, `in`.length())
+            }
+            assertTrue(exception!!.message!!.contains("codec footer mismatch"))
+            assertEquals(0, exception.suppressedExceptions.size)
+
+            exception = expectThrows(CorruptIndexException::class) {
+                CodecUtil.retrieveChecksum(`in`, `in`.length() - 1)
+            }
+            assertTrue(exception!!.message!!.contains("too long"))
+
+            exception = expectThrows(CorruptIndexException::class) {
+                CodecUtil.retrieveChecksum(`in`, `in`.length() + 1)
+            }
+            assertTrue(exception!!.message!!.contains("truncated"))
+        }
+
+        dir.close()
+    }
+}
+

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/document/TestDateTools.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/document/TestDateTools.kt
@@ -1,0 +1,156 @@
+package org.gnit.lucenekmp.document
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.number
+import org.gnit.lucenekmp.jdkport.ParseException
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class TestDateTools : LuceneTestCase() {
+
+    @Test
+    fun testStringToDate() {
+        var d = DateTools.stringToDate("2004")
+        assertEquals("2004-01-01 00:00:00:000", isoFormat(d))
+        d = DateTools.stringToDate("20040705")
+        assertEquals("2004-07-05 00:00:00:000", isoFormat(d))
+        d = DateTools.stringToDate("200407050910")
+        assertEquals("2004-07-05 09:10:00:000", isoFormat(d))
+        d = DateTools.stringToDate("20040705091055990")
+        assertEquals("2004-07-05 09:10:55:990", isoFormat(d))
+
+        expectThrows(ParseException::class) { DateTools.stringToDate("97") }
+        expectThrows(ParseException::class) { DateTools.stringToDate("200401011235009999") }
+        expectThrows(ParseException::class) { DateTools.stringToDate("aaaa") }
+    }
+
+    @Test
+    fun testStringtoTime() {
+        var time = DateTools.stringToTime("197001010000")
+        assertEquals(0L, time)
+        val cal = LocalDateTime(1980, 2, 2, 11, 5, 0)
+        time = DateTools.stringToTime("198002021105")
+        assertEquals(cal.toInstant(TimeZone.UTC).toEpochMilliseconds(), time)
+    }
+
+    @Test
+    fun testDateAndTimetoString() {
+        var cal = LocalDateTime(2004, 2, 3, 22, 8, 56, 333_000_000)
+
+        var dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.YEAR)
+        assertEquals("2004", dateString)
+        assertEquals("2004-01-01 00:00:00:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.MONTH)
+        assertEquals("200402", dateString)
+        assertEquals("2004-02-01 00:00:00:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.DAY)
+        assertEquals("20040203", dateString)
+        assertEquals("2004-02-03 00:00:00:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.HOUR)
+        assertEquals("2004020322", dateString)
+        assertEquals("2004-02-03 22:00:00:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.MINUTE)
+        assertEquals("200402032208", dateString)
+        assertEquals("2004-02-03 22:08:00:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.SECOND)
+        assertEquals("20040203220856", dateString)
+        assertEquals("2004-02-03 22:08:56:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.MILLISECOND)
+        assertEquals("20040203220856333", dateString)
+        assertEquals("2004-02-03 22:08:56:333", isoFormat(DateTools.stringToDate(dateString)))
+
+        cal = LocalDateTime(1961, 3, 5, 23, 9, 51, 444_000_000)
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.MILLISECOND)
+        assertEquals("19610305230951444", dateString)
+        assertEquals("1961-03-05 23:09:51:444", isoFormat(DateTools.stringToDate(dateString)))
+
+        dateString = DateTools.dateToString(cal.toInstant(TimeZone.UTC), DateTools.Resolution.HOUR)
+        assertEquals("1961030523", dateString)
+        assertEquals("1961-03-05 23:00:00:000", isoFormat(DateTools.stringToDate(dateString)))
+
+        cal = LocalDateTime(1970, 1, 1, 0, 0, 0)
+        dateString = DateTools.timeToString(cal.toInstant(TimeZone.UTC).toEpochMilliseconds(), DateTools.Resolution.MILLISECOND)
+        assertEquals("19700101000000000", dateString)
+
+        cal = LocalDateTime(1970, 1, 1, 1, 2, 3)
+        dateString = DateTools.timeToString(cal.toInstant(TimeZone.UTC).toEpochMilliseconds(), DateTools.Resolution.MILLISECOND)
+        assertEquals("19700101010203000", dateString)
+    }
+
+    @Test
+    fun testRound() {
+        val cal = LocalDateTime(2004, 2, 3, 22, 8, 56, 333_000_000)
+        val date = cal.toInstant(TimeZone.UTC)
+        assertEquals("2004-02-03 22:08:56:333", isoFormat(date))
+
+        val dateYear = DateTools.round(date, DateTools.Resolution.YEAR)
+        assertEquals("2004-01-01 00:00:00:000", isoFormat(dateYear))
+
+        val dateMonth = DateTools.round(date, DateTools.Resolution.MONTH)
+        assertEquals("2004-02-01 00:00:00:000", isoFormat(dateMonth))
+
+        val dateDay = DateTools.round(date, DateTools.Resolution.DAY)
+        assertEquals("2004-02-03 00:00:00:000", isoFormat(dateDay))
+
+        val dateHour = DateTools.round(date, DateTools.Resolution.HOUR)
+        assertEquals("2004-02-03 22:00:00:000", isoFormat(dateHour))
+
+        val dateMinute = DateTools.round(date, DateTools.Resolution.MINUTE)
+        assertEquals("2004-02-03 22:08:00:000", isoFormat(dateMinute))
+
+        val dateSecond = DateTools.round(date, DateTools.Resolution.SECOND)
+        assertEquals("2004-02-03 22:08:56:000", isoFormat(dateSecond))
+
+        val dateMillisecond = DateTools.round(date, DateTools.Resolution.MILLISECOND)
+        assertEquals("2004-02-03 22:08:56:333", isoFormat(dateMillisecond))
+
+        val dateYearLong = DateTools.round(date.toEpochMilliseconds(), DateTools.Resolution.YEAR)
+        assertEquals("2004-01-01 00:00:00:000", isoFormat(Instant.fromEpochMilliseconds(dateYearLong)))
+
+        val dateMillisecondLong = DateTools.round(date.toEpochMilliseconds(), DateTools.Resolution.MILLISECOND)
+        assertEquals("2004-02-03 22:08:56:333", isoFormat(Instant.fromEpochMilliseconds(dateMillisecondLong)))
+    }
+
+    @Test
+    fun testDateToolsUTC() {
+        val time = 1130630400L
+        val d1 = DateTools.dateToString(Instant.fromEpochSeconds(time), DateTools.Resolution.MINUTE)
+        val d2 = DateTools.dateToString(Instant.fromEpochSeconds(time + 3600), DateTools.Resolution.MINUTE)
+        assertFalse(d1 == d2, "different times")
+        assertEquals(time * 1000, DateTools.stringToTime(d1), "midnight")
+        assertEquals((time + 3600) * 1000, DateTools.stringToTime(d2), "later")
+    }
+
+    private fun isoFormat(instant: Instant): String {
+        val dt = instant.toLocalDateTime(DateTools.GMT)
+        fun pad2(v: Int) = if (v < 10) "0$v" else "$v"
+        fun pad3(v: Int) = when {
+            v < 10 -> "00$v"
+            v < 100 -> "0$v"
+            else -> "$v"
+        }
+        val y = dt.year.toString().padStart(4, '0')
+        val M = pad2(dt.month.number)
+        val d = pad2(dt.day)
+        val h = pad2(dt.hour)
+        val m = pad2(dt.minute)
+        val s = pad2(dt.second)
+        val ms = pad3(dt.nanosecond / 1_000_000)
+        return "$y-$M-$d $h:$m:$s:$ms"
+    }
+}
+

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/document/TestDateTools.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/document/TestDateTools.kt
@@ -9,7 +9,7 @@ import org.gnit.lucenekmp.jdkport.ParseException
 import org.gnit.lucenekmp.tests.util.LuceneTestCase
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -127,12 +127,12 @@ class TestDateTools : LuceneTestCase() {
 
     @Test
     fun testDateToolsUTC() {
-        val time = 1130630400L
+        val time = 1_130_630_400L
         val d1 = DateTools.dateToString(Instant.fromEpochSeconds(time), DateTools.Resolution.MINUTE)
-        val d2 = DateTools.dateToString(Instant.fromEpochSeconds(time + 3600), DateTools.Resolution.MINUTE)
-        assertFalse(d1 == d2, "different times")
-        assertEquals(time * 1000, DateTools.stringToTime(d1), "midnight")
-        assertEquals((time + 3600) * 1000, DateTools.stringToTime(d2), "later")
+        val d2 = DateTools.dateToString(Instant.fromEpochSeconds(time + 3_600), DateTools.Resolution.MINUTE)
+        assertNotEquals(d1, d2, "different times")
+        assertEquals(time * 1_000, DateTools.stringToTime(d1), "midnight")
+        assertEquals((time + 3_600) * 1_000, DateTools.stringToTime(d2), "later")
     }
 
     private fun isoFormat(instant: Instant): String {
@@ -145,7 +145,7 @@ class TestDateTools : LuceneTestCase() {
         }
         val y = dt.year.toString().padStart(4, '0')
         val M = pad2(dt.month.number)
-        val d = pad2(dt.day)
+        val d = pad2(dt.dayOfMonth)
         val h = pad2(dt.hour)
         val m = pad2(dt.minute)
         val s = pad2(dt.second)


### PR DESCRIPTION
## Summary
- port `TestDateTools` from Java to Kotlin common tests
- verify DateTools string conversions, rounding, and timezone behavior

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.document.TestDateTools`
- `./gradlew jvmTest`
- `./gradlew allTests` *(fails: Failed to find Build Tools revision 35.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b937c9c220832b9937dc9a49fdd6cf