### PR TITLE
Fix flaky test: bound determinization in TestOperations.testDuelRepeat/testDuelOptional (fixes #189)

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/automaton/TestOperations.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/automaton/TestOperations.kt
@@ -302,7 +302,7 @@ class TestOperations : LuceneTestCase() {
             )
         assertFalse(Operations.isTotal(tricky3))
         val tricky4: Automaton =
-            Operations.repeat(
+        	    Operations.repeat(
                 Operations.union(
                     mutableListOf(
                         Automata.makeCharRange(
@@ -635,27 +635,33 @@ class TestOperations : LuceneTestCase() {
         }
     }
 
-    // TODO, this test hangs sometimes, needs to be fixed!
+    // Previously flaky due to unbounded determinization; now bounded and skips TooComplex cases.
     @Test
     fun testDuelRepeat() {
         val iters: Int = atLeast(10) // TODO originally 1_000 but reduced to 10 for dev speed
+        val determinizeWorkLimit = DEFAULT_DETERMINIZE_WORK_LIMIT
         for (iter in 0..<iters) {
             val a: Automaton =
                 AutomatonTestUtil.randomAutomaton(random())
-            val repeat1: Automaton =
-                Operations.determinize(
-                    Operations.repeat(a), Int.MAX_VALUE
+            try {
+                val repeat1: Automaton =
+                    Operations.determinize(
+                        Operations.repeat(a), determinizeWorkLimit
+                    )
+                val repeat2: Automaton =
+                    Operations.determinize(
+                        naiveRepeat(a), determinizeWorkLimit
+                    )
+                assertTrue(
+                    AutomatonTestUtil.sameLanguage(
+                        repeat1,
+                        repeat2
+                    )
                 )
-            val repeat2: Automaton =
-                Operations.determinize(
-                    naiveRepeat(a), Int.MAX_VALUE
-                )
-            assertTrue(
-                AutomatonTestUtil.sameLanguage(
-                    repeat1,
-                    repeat2
-                )
-            )
+            } catch (e: TooComplexToDeterminizeException) {
+                // skip this iteration if determinization is too complex
+                continue
+            }
         }
     }
 
@@ -759,23 +765,29 @@ class TestOperations : LuceneTestCase() {
     @Test
     fun testDuelOptional() {
         val iters: Int = atLeast(10) // TODO originally 1_000 but reduced to 10 for dev speed
+        val determinizeWorkLimit = DEFAULT_DETERMINIZE_WORK_LIMIT
         for (iter in 0..<iters) {
             val a: Automaton =
                 AutomatonTestUtil.randomAutomaton(random())
-            val repeat1: Automaton =
-                Operations.determinize(
-                    Operations.optional(a), Int.MAX_VALUE
+            try {
+                val repeat1: Automaton =
+                    Operations.determinize(
+                        Operations.optional(a), determinizeWorkLimit
+                    )
+                val repeat2: Automaton =
+                    Operations.determinize(
+                        naiveOptional(a), determinizeWorkLimit
+                    )
+                assertTrue(
+                    AutomatonTestUtil.sameLanguage(
+                        repeat1,
+                        repeat2
+                    )
                 )
-            val repeat2: Automaton =
-                Operations.determinize(
-                    naiveOptional(a), Int.MAX_VALUE
-                )
-            assertTrue(
-                AutomatonTestUtil.sameLanguage(
-                    repeat1,
-                    repeat2
-                )
-            )
+            } catch (e: TooComplexToDeterminizeException) {
+                // skip this iteration if determinization is too complex
+                continue
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses issue #189.

Problem
- TestOperations.testDuelRepeat() could hang due to unbounded determinization (Int.MAX_VALUE), depending on random automata.
- testDuelOptional() used the same pattern and could exhibit similar behavior.

Changes
- Use Operations.DEFAULT_DETERMINIZE_WORK_LIMIT for determinization in:
  - testDuelRepeat()
  - testDuelOptional()
- Wrap determinize calls with try/catch and skip iterations that throw TooComplexToDeterminizeException, mirroring patterns used in nearby tests.
- Updated the flaky-test comment above testDuelRepeat to note the new bounded/skip behavior.

Why
- Prevents intermittent hangs and reduces CI flakiness while preserving the property-based test intent.

Validation
- Local compile check shows no errors (only unused-variable warnings in loops). CI will run the full matrix.

Follow-ups (optional)
- If we still see rare timeouts, consider adding a per-iteration timeout via the test runner or reducing random automata complexity further.