### PR TITLE
Clarify CancellationException usage in FutureTask

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FutureTask.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/jdkport/FutureTask.kt
@@ -1,12 +1,22 @@
 package org.gnit.lucenekmp.jdkport
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.fetchAndIncrement
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.time.Duration
@@ -140,7 +150,7 @@ open class FutureTask<V> : RunnableFuture<V> {
         if (s == NORMAL)
             return x as V
         if (s >= CANCELLED)
-            throw CancellationException("Task was cancelled") as Throwable
+            throw CancellationException("Task was cancelled")
         throw ExecutionException(x as Throwable)
     }
 


### PR DESCRIPTION
## Summary
- Import kotlin's standard `CancellationException` in `FutureTask` and replace wildcard coroutine imports
- Use `CancellationException` explicitly when reporting cancelled tasks

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew jvmTest`


------
https://chatgpt.com/codex/tasks/task_e_68bcdc8682a0832baf41eedee64ba245