### PR TITLE
Stabilize LimitedFiniteStringsIterator to prevent random test hang (Fixes #203)

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/automaton/LimitedFiniteStringsIterator.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/automaton/LimitedFiniteStringsIterator.kt
@@ -1,6 +1,7 @@
 package org.gnit.lucenekmp.util.automaton
 
 import org.gnit.lucenekmp.util.IntsRef
+import org.gnit.lucenekmp.jdkport.BitSet
 
 /**
  * [FiniteStringsIterator] which limits the number of iterated accepted strings. If more than
@@ -31,6 +32,13 @@ class LimitedFiniteStringsIterator(a: Automaton, limit: Int) :
     init {
         require(!(limit != -1 && limit <= 0)) { "limit must be -1 (which means no limit), or > 0; got: $limit" }
 
+        // Fail fast if the automaton has a cycle reachable from the initial state.
+        // FiniteStringsIterator would eventually throw when hitting the cycle; we detect it upfront
+        // to avoid rare long iterations on cyclic automata.
+        if (hasReachableCycle(a)) {
+            throw IllegalArgumentException("automaton has cycles")
+        }
+
         this.limit = if (limit > 0) limit else Int.Companion.MAX_VALUE
     }
 
@@ -51,5 +59,42 @@ class LimitedFiniteStringsIterator(a: Automaton, limit: Int) :
     /** Number of iterated finite strings.  */
     fun size(): Int {
         return count
+    }
+
+    /**
+     * Detects whether there is any cycle reachable from the initial state (state 0).
+     * This matches the runtime behavior of FiniteStringsIterator which throws on cycles
+     * encountered along a path during enumeration.
+     */
+    private fun hasReachableCycle(a: Automaton): Boolean {
+        if (a.numStates == 0) return false
+        val onPath = BitSet(a.numStates)
+        val visited = BitSet(a.numStates)
+        // stack of pairs (state, nextTransitionIndex)
+        data class Frame(var state: Int, var nextIdx: Int, var num: Int)
+        val stack = ArrayDeque<Frame>()
+        stack.addLast(Frame(0, 0, a.getNumTransitions(0)))
+        onPath.set(0)
+        val t = Transition()
+        while (stack.isNotEmpty()) {
+            val f = stack.last()
+            if (f.nextIdx < f.num) {
+                a.getTransition(f.state, f.nextIdx, t)
+                f.nextIdx++
+                val dest = t.dest
+                if (onPath.get(dest)) {
+                    return true
+                }
+                if (!visited.get(dest)) {
+                    onPath.set(dest)
+                    stack.addLast(Frame(dest, 0, a.getNumTransitions(dest)))
+                }
+            } else {
+                visited.set(f.state)
+                onPath.clear(f.state)
+                stack.removeLast()
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
This PR stabilizes `LimitedFiniteStringsIterator` to address intermittent hangs observed in `TestLimitedFiniteStringsIterator.testRandomFiniteStrings`.

- Avoids potential non-terminating iteration conditions
- Improves termination checks and iteration safety

Reference issue: Fixes #203

CI example of hang referenced in the issue: https://github.com/nehemiaharchives/lucene-kmp/actions/runs/17520181581/job/49764100018?pr=201

Please review. After merge, this should close #203.