### PR TITLE
Port TestLockableConcurrentApproximatePriorityQueue to Kotlin

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -39,7 +39,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.index.TestIndexWriter -> org.apache.lucene.index.IndexWriter (Ported)
 - org.apache.lucene.index.TestIndexWriterConfig -> org.apache.lucene.index.IndexWriterConfig (Ported)
 - org.apache.lucene.index.TestIndexableField -> org.apache.lucene.index.IndexableField (Ported)
-- org.apache.lucene.index.TestLockableConcurrentApproximatePriorityQueue -> org.apache.lucene.index.LockableConcurrentApproximatePriorityQueue (Ported)
 - org.apache.lucene.index.TestMultiFields -> org.apache.lucene.index.MultiFields (Ported)
 - org.apache.lucene.index.TestOneMergeWrappingMergePolicy -> org.apache.lucene.index.OneMergeWrappingMergePolicy (Ported)
 - org.apache.lucene.index.TestPendingDeletes -> org.apache.lucene.index.PendingDeletes (Ported)

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestLockableConcurrentApproximatePriorityQueue.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestLockableConcurrentApproximatePriorityQueue.kt
@@ -1,0 +1,73 @@
+package org.gnit.lucenekmp.index
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.gnit.lucenekmp.jdkport.Condition
+import org.gnit.lucenekmp.jdkport.Lock
+import org.gnit.lucenekmp.jdkport.ReentrantLock
+import org.gnit.lucenekmp.jdkport.TimeUnit
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.TestUtil
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class TestLockableConcurrentApproximatePriorityQueue : LuceneTestCase() {
+
+    private class WeightedLock : Lock {
+        private val lock: Lock = ReentrantLock()
+        var weight: Long = 0
+
+        override fun lock() {
+            lock.lock()
+        }
+
+        override fun lockInterruptibly() {
+            throw UnsupportedOperationException()
+        }
+
+        override fun tryLock(): Boolean {
+            return lock.tryLock()
+        }
+
+        override fun tryLock(time: Long, unit: TimeUnit): Boolean {
+            throw UnsupportedOperationException()
+        }
+
+        override fun unlock() {
+            lock.unlock()
+        }
+
+        override fun newCondition(): Condition {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    @Test
+    fun testNeverReturnNullOnNonEmptyQueue() = runBlocking {
+        val iters = atLeast(10)
+        repeat(iters) {
+            val concurrency = TestUtil.nextInt(random(), 1, 16)
+            val queue = LockableConcurrentApproximatePriorityQueue<WeightedLock>(concurrency)
+            val numThreads = TestUtil.nextInt(random(), 2, 16)
+            val startingGun = CompletableDeferred<Unit>()
+            val jobs = Array(numThreads) {
+                launch {
+                    startingGun.await()
+                    var lock = WeightedLock()
+                    lock.lock()
+                    lock.weight++
+                    queue.addAndUnlock(lock, lock.weight)
+                    repeat(10_000) {
+                        val l = queue.lockAndPoll()
+                        assertNotNull(l)
+                        queue.addAndUnlock(l, l.hashCode().toLong())
+                    }
+                }
+            }
+            startingGun.complete(Unit)
+            jobs.forEach { it.join() }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- port LockableConcurrentApproximatePriorityQueue test to Kotlin using coroutines
- remove completed test from TODO list

## Testing
- `./gradlew --console=plain compileKotlinJvm`
- `./gradlew --console=plain compileTestKotlinJvm`
- `./gradlew --console=plain core:jvmTest --tests org.gnit.lucenekmp.index.TestLockableConcurrentApproximatePriorityQueue --rerun-tasks`
- `./gradlew --console=plain jvmTest`


------
https://chatgpt.com/codex/tasks/task_e_68bed1e6f18c832bb33463196103a430