### PR TITLE
Port TestNIOFSDirectory

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -60,7 +60,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.search.TestTopDocsCollector -> org.apache.lucene.search.TopDocsCollector (Ported)
 - org.apache.lucene.search.TestVectorScorer -> org.apache.lucene.search.VectorScorer (Ported)
 - org.apache.lucene.store.TestLockFactory -> org.apache.lucene.store.LockFactory (Ported)
-- org.apache.lucene.store.TestNIOFSDirectory -> org.apache.lucene.store.NIOFSDirectory (Ported)
 - org.apache.lucene.tests.util.TestRuleTemporaryFilesCleanup -> org.apache.lucene.tests.util.TestRuleTemporaryFilesCleanup
 - org.apache.lucene.util.TestCloseableThreadLocal -> org.apache.lucene.util.CloseableThreadLocal (Ported)
 - org.apache.lucene.util.fst.TestBitTableUtil -> org.apache.lucene.util.fst.BitTableUtil (Ported)

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/store/TestNIOFSDirectory.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/store/TestNIOFSDirectory.kt
@@ -1,0 +1,82 @@
+package org.gnit.lucenekmp.store
+
+import okio.fakefilesystem.FakeFileSystem
+import okio.FileHandle
+import okio.Path
+import okio.IOException
+import okio.ForwardingFileSystem
+import org.gnit.lucenekmp.jdkport.toRealPath
+import org.gnit.lucenekmp.jdkport.Files
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.tests.store.BaseDirectoryTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TestNIOFSDirectory : BaseDirectoryTestCase() {
+    override fun getDirectory(path: Path): Directory {
+        return NIOFSDirectory(path)
+    }
+
+    @Test
+    fun testHandleExceptionInConstructor() {
+        // Create a filesystem that throws when size() is called on a FileHandle
+        val leakFs = object : ForwardingFileSystem(FakeFileSystem()) {
+            override fun openReadOnly(file: Path): FileHandle {
+                val delegate = super.openReadOnly(file)
+                return object : FileHandle(delegate.readWrite) {
+                    override fun protectedRead(
+                        fileOffset: Long,
+                        array: ByteArray,
+                        arrayOffset: Int,
+                        byteCount: Int,
+                    ): Int {
+                        return delegate.read(fileOffset, array, arrayOffset, byteCount)
+                    }
+
+                    override fun protectedWrite(
+                        fileOffset: Long,
+                        array: ByteArray,
+                        arrayOffset: Int,
+                        byteCount: Int,
+                    ) {
+                        delegate.write(fileOffset, array, arrayOffset, byteCount)
+                    }
+
+                    override fun protectedFlush() {
+                        delegate.flush()
+                    }
+
+                    override fun protectedResize(size: Long) {
+                        delegate.resize(size)
+                    }
+
+                    override fun protectedSize(): Long {
+                        throw IOException("simulated")
+                    }
+
+                    override fun protectedClose() {
+                        delegate.close()
+                    }
+                }
+            }
+        }
+
+        Files.setFileSystem(leakFs)
+        try {
+            val path = createTempDir("niofs").toRealPath()
+            NIOFSDirectory(path).use { dir ->
+                dir.createOutput("test.bin", IOContext.DEFAULT).use { out ->
+                    out.writeString("hello")
+                }
+                val error = assertFailsWith<IOException> {
+                    dir.openInput("test.bin", IOContext.DEFAULT)
+                }
+                assertEquals("simulated", error.message)
+            }
+        } finally {
+            Files.resetFileSystem()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- port `TestNIOFSDirectory` to kotlin common tests
- remove TODO entry for `TestNIOFSDirectory`

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.store.TestNIOFSDirectory`
- `./gradlew jvmTest`


------
https://chatgpt.com/codex/tasks/task_e_68bed69f4ce8832b9d6e0d80a23b0792