### PR TITLE
Port TestTimeLimitingBulkScorer

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -56,7 +56,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.search.TestMatchesIterator -> org.apache.lucene.search.MatchesIterator (Ported)
 - org.apache.lucene.search.TestReqExclBulkScorer -> org.apache.lucene.search.ReqExclBulkScorer (Ported)
 - org.apache.lucene.search.TestTermScorer -> org.apache.lucene.search.TermScorer (Ported)
-- org.apache.lucene.search.TestTimeLimitingBulkScorer -> org.apache.lucene.search.TimeLimitingBulkScorer (Ported)
 - org.apache.lucene.search.TestTopDocsCollector -> org.apache.lucene.search.TopDocsCollector (Ported)
 - org.apache.lucene.search.TestVectorScorer -> org.apache.lucene.search.VectorScorer (Ported)
 - org.apache.lucene.store.TestLockFactory -> org.apache.lucene.store.LockFactory (Ported)

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/TopScoreDocCollector.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/TopScoreDocCollector.kt
@@ -81,17 +81,12 @@ class TopScoreDocCollector internal constructor(
             private var minCompetitiveScore = 0f
 
             override var scorer: Scorable? = null
-                get() {
-                    throw UnsupportedOperationException(
-                        "Scorer cannot be set directly on TopScoreDocCollector. Use setScorer instead."
-                    )
-                }
-                set(scorer) {
-                    field = scorer
+                set(value) {
+                    field = value
                     if (minScoreAcc == null) {
-                        updateMinCompetitiveScore(scorer!!)
+                        updateMinCompetitiveScore(value!!)
                     } else {
-                        updateGlobalMinCompetitiveScore(scorer!!)
+                        updateGlobalMinCompetitiveScore(value!!)
                     }
                 }
 

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestTimeLimitingBulkScorer.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestTimeLimitingBulkScorer.kt
@@ -1,0 +1,103 @@
+package org.gnit.lucenekmp.search
+
+import org.gnit.lucenekmp.document.Document
+import org.gnit.lucenekmp.document.Field
+import org.gnit.lucenekmp.document.TextField
+import org.gnit.lucenekmp.index.DirectoryReader
+import org.gnit.lucenekmp.index.IndexWriter
+import org.gnit.lucenekmp.index.IndexWriterConfig
+import org.gnit.lucenekmp.index.Term
+import org.gnit.lucenekmp.index.QueryTimeout
+import org.gnit.lucenekmp.store.ByteBuffersDirectory
+import org.gnit.lucenekmp.tests.analysis.MockAnalyzer
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.util.Bits
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class TestTimeLimitingBulkScorer : LuceneTestCase() {
+
+    @Test
+    fun testTimeLimitingBulkScorer() {
+        val directory = ByteBuffersDirectory()
+        val writer = IndexWriter(directory, IndexWriterConfig(MockAnalyzer(random())))
+        val n = 10000
+        for (i in 0 until n) {
+            val d = Document()
+            d.add(TextField("default", "ones ", Field.Store.YES))
+            writer.addDocument(d)
+        }
+        writer.forceMerge(1)
+        writer.commit()
+        writer.close()
+
+        val query = TermQuery(Term("default", "ones"))
+        val directoryReader = DirectoryReader.open(directory)
+        val searcher = IndexSearcher(directoryReader)
+        searcher.timeout = countingQueryTimeout(10)
+        val top = searcher.search(query, n)
+        val hits = top.scoreDocs
+        assertTrue(
+            hits.isNotEmpty() && hits.size < n && searcher.timedOut(),
+            "Partial result and is aborted is true"
+        )
+        directoryReader.close()
+        directory.close()
+    }
+
+    @Test
+    fun testExponentialRate() {
+        val MAX_DOCS = DocIdSetIterator.NO_MORE_DOCS - 1
+        val bulkScorer = object : BulkScorer() {
+            var expectedInterval = TimeLimitingBulkScorer.INTERVAL
+            var lastMax = 0
+            var lastInterval = 0
+
+            override fun score(collector: LeafCollector, acceptDocs: Bits?, min: Int, max: Int): Int {
+                val difference = max - min
+                assertTrue(difference >= lastInterval, "Rate should only go up")
+                assertTrue(lastMax == min, "Documents skipped")
+                assertTrue(
+                    if (max == MAX_DOCS) expectedInterval >= difference else expectedInterval == difference,
+                    "Incorrect rate encountered"
+                )
+
+                lastMax = max
+                lastInterval = difference
+
+                expectedInterval = expectedInterval + expectedInterval / 2
+                if (expectedInterval < 0) {
+                    expectedInterval = lastInterval
+                }
+                return max
+            }
+
+            override fun cost(): Long {
+                return 1
+            }
+        }
+
+        val scorer = TimeLimitingBulkScorer(bulkScorer, object : QueryTimeout {
+            override fun shouldExit(): Boolean = false
+        })
+        scorer.score(dummyCollector(), Bits.MatchAllBits(Int.MAX_VALUE), 0, MAX_DOCS)
+    }
+
+    private fun countingQueryTimeout(timeallowed: Int): QueryTimeout {
+        return object : QueryTimeout {
+            var counter = 0
+            override fun shouldExit(): Boolean {
+                counter++
+                return counter == timeallowed
+            }
+        }
+    }
+
+    private fun dummyCollector(): LeafCollector {
+        return object : LeafCollector {
+            override var scorer: Scorable? = null
+            override fun collect(doc: Int) {}
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- port `TestTimeLimitingBulkScorer` from Lucene to Kotlin common tests
- fix `TopScoreDocCollector` scorer handling to support scoring
- update TODO list

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.search.TestTimeLimitingBulkScorer`
- `./gradlew jvmTest`
- `./gradlew allTests` *(fails: Failed to find Build Tools revision 35.0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68bedfb41c30832bbeed4fb22a630b32