### PR TITLE
Port TestDisjunctionScoreBlockBoundaryPropagator

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -49,7 +49,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.search.TestBooleanQuery -> org.apache.lucene.search.BooleanQuery (Ported)
 - org.apache.lucene.search.TestCollectorManager -> org.apache.lucene.search.CollectorManager (Ported)
 - org.apache.lucene.search.TestDisiPriorityQueue -> org.apache.lucene.search.DisiPriorityQueue (Ported)
-- org.apache.lucene.search.TestDisjunctionScoreBlockBoundaryPropagator -> org.apache.lucene.search.DisjunctionScoreBlockBoundaryPropagator (Ported)
 - org.apache.lucene.search.TestIndexSearcher -> org.apache.lucene.search.IndexSearcher (Ported)
 - org.apache.lucene.search.TestKnnByteVectorQuery -> org.apache.lucene.search.KnnByteVectorQuery (Ported)
 - org.apache.lucene.search.TestKnnFloatVectorQuery -> org.apache.lucene.search.KnnFloatVectorQuery (Ported)

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestDisjunctionScoreBlockBoundaryPropagator.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestDisjunctionScoreBlockBoundaryPropagator.kt
@@ -1,0 +1,70 @@
+package org.gnit.lucenekmp.search
+
+import okio.IOException
+import org.gnit.lucenekmp.search.DocIdSetIterator
+import org.gnit.lucenekmp.search.DisjunctionScoreBlockBoundaryPropagator
+import org.gnit.lucenekmp.search.Scorer
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestDisjunctionScoreBlockBoundaryPropagator : LuceneTestCase() {
+
+    private class FakeScorer(
+        private val boundary: Int,
+        private val maxScore: Float
+    ) : Scorer() {
+
+        override fun docID(): Int {
+            return 0
+        }
+
+        override fun score(): Float {
+            throw UnsupportedOperationException()
+        }
+
+        override fun iterator(): DocIdSetIterator {
+            throw UnsupportedOperationException()
+        }
+
+        override fun getMaxScore(upTo: Int): Float {
+            return maxScore
+        }
+
+        override fun advanceShallow(target: Int): Int {
+            require(target <= boundary)
+            return boundary
+        }
+    }
+
+    @Test
+    fun testBasics() {
+        val scorer1: Scorer = FakeScorer(20, 0.5f)
+        val scorer2: Scorer = FakeScorer(50, 1.5f)
+        val scorer3: Scorer = FakeScorer(30, 2f)
+        val scorer4: Scorer = FakeScorer(80, 3f)
+        val scorers = mutableListOf(scorer1, scorer2, scorer3, scorer4)
+        scorers.shuffle(random())
+        val propagator = DisjunctionScoreBlockBoundaryPropagator(scorers)
+        assertEquals(20, propagator.advanceShallow(0))
+
+        propagator.setMinCompetitiveScore(0.2f)
+        assertEquals(20, propagator.advanceShallow(0))
+
+        propagator.setMinCompetitiveScore(0.7f)
+        assertEquals(30, propagator.advanceShallow(0))
+
+        propagator.setMinCompetitiveScore(1.2f)
+        assertEquals(30, propagator.advanceShallow(0))
+
+        propagator.setMinCompetitiveScore(1.7f)
+        assertEquals(30, propagator.advanceShallow(0))
+
+        propagator.setMinCompetitiveScore(2.2f)
+        assertEquals(80, propagator.advanceShallow(0))
+
+        propagator.setMinCompetitiveScore(5f)
+        assertEquals(80, propagator.advanceShallow(0))
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Kotlin test for DisjunctionScoreBlockBoundaryPropagator
- remove completed test entry from TODO_TEST

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.search.TestDisjunctionScoreBlockBoundaryPropagator --rerun-tasks`
- `./gradlew jvmTest`
- `./gradlew allTests` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed3a81104832b903d0a87b63266eb