### PR TITLE
Port TestCollectorManager collector test

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -46,7 +46,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.index.TestTermVectorsReader -> org.apache.lucene.codecs.TermVectorsReader (Ported)
 - org.apache.lucene.internal.vectorization.TestVectorScorer -> org.apache.lucene.search.VectorScorer (Ported)
 - org.apache.lucene.search.TestBooleanQuery -> org.apache.lucene.search.BooleanQuery (Ported)
-- org.apache.lucene.search.TestCollectorManager -> org.apache.lucene.search.CollectorManager (Ported)
 - org.apache.lucene.search.TestDisiPriorityQueue -> org.apache.lucene.search.DisiPriorityQueue (Ported)
 - org.apache.lucene.search.TestIndexSearcher -> org.apache.lucene.search.IndexSearcher (Ported)
 - org.apache.lucene.search.TestKnnByteVectorQuery -> org.apache.lucene.search.KnnByteVectorQuery (Ported)

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/MultiCollector.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/MultiCollector.kt
@@ -1,0 +1,88 @@
+package org.gnit.lucenekmp.search
+
+import okio.IOException
+import org.gnit.lucenekmp.index.LeafReaderContext
+
+/**
+ * Port of Lucene's MultiCollector that dispatches collection to multiple collectors.
+ */
+class MultiCollector private constructor(private val collectors: Array<Collector>) : Collector {
+
+    companion object {
+        /** Wraps the given collectors, ignoring nulls and collapsing to a single collector if possible. */
+        fun wrap(collectors: Iterable<Collector?>): Collector {
+            val filtered = collectors.filterNotNull()
+            require(filtered.isNotEmpty()) { "At least 1 collector must not be null" }
+            return if (filtered.size == 1) {
+                filtered[0]
+            } else {
+                MultiCollector(filtered.toTypedArray())
+            }
+        }
+
+        fun wrap(vararg collectors: Collector?): Collector {
+            return wrap(collectors.asList())
+        }
+    }
+
+    override fun scoreMode(): ScoreMode {
+        var scoreMode: ScoreMode? = null
+        for (c in collectors) {
+            scoreMode = when {
+                scoreMode == null -> c.scoreMode()
+                scoreMode != c.scoreMode() -> {
+                    if (scoreMode!!.needsScores() || c.scoreMode().needsScores()) {
+                        ScoreMode.COMPLETE
+                    } else {
+                        ScoreMode.COMPLETE_NO_SCORES
+                    }
+                }
+                else -> scoreMode
+            }
+        }
+        return scoreMode ?: ScoreMode.COMPLETE
+    }
+
+    @Throws(IOException::class)
+    override fun getLeafCollector(context: LeafReaderContext): LeafCollector {
+        val leafCollectors = mutableListOf<LeafCollector>()
+        for (collector in collectors) {
+            try {
+                leafCollectors.add(collector.getLeafCollector(context))
+            } catch (_: CollectionTerminatedException) {
+                // ignore collectors that do not need this segment
+            }
+        }
+        if (leafCollectors.isEmpty()) {
+            throw CollectionTerminatedException()
+        }
+        val delegates = leafCollectors.toTypedArray()
+        return object : LeafCollector {
+            @Throws(IOException::class)
+            override fun setScorer(scorer: Scorable) {
+                for (lc in delegates) {
+                    lc.setScorer(scorer)
+                }
+            }
+
+            @Throws(IOException::class)
+            override fun collect(doc: Int) {
+                for (lc in delegates) {
+                    lc.collect(doc)
+                }
+            }
+        }
+    }
+
+    override var weight: Weight? = null
+        set(value) {
+            field = value
+            for (collector in collectors) {
+                collector.weight = value
+            }
+        }
+
+    /** Provides access to the wrapped collectors for advanced use-cases. */
+    fun getCollectors(): Array<Collector> = collectors
+}
+

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestCollectorManager.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestCollectorManager.kt
@@ -1,0 +1,142 @@
+package org.gnit.lucenekmp.search
+
+import org.gnit.lucenekmp.document.Document
+import org.gnit.lucenekmp.index.DirectoryReader
+import org.gnit.lucenekmp.index.IndexWriter
+import org.gnit.lucenekmp.index.IndexWriterConfig
+import org.gnit.lucenekmp.index.LeafReaderContext
+import org.gnit.lucenekmp.search.Collector
+import org.gnit.lucenekmp.search.CollectorManager
+import org.gnit.lucenekmp.search.MultiCollector
+import org.gnit.lucenekmp.search.ScoreMode
+import org.gnit.lucenekmp.search.Scorable
+import org.gnit.lucenekmp.search.Weight
+import org.gnit.lucenekmp.store.ByteBuffersDirectory
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.RandomNumbers
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+class TestCollectorManager : LuceneTestCase() {
+
+    @Test
+    fun testCollection() {
+        val dir = newDirectory()
+        val reader = reader(dir)
+        val ctx = reader.leaves()[0]
+
+        val evenPredicate: (Int) -> Boolean = { it % 2 == 0 }
+        val oddPredicate: (Int) -> Boolean = { it % 2 == 1 }
+
+        val cm = CompositeCollectorManager(listOf(evenPredicate, oddPredicate))
+
+        repeat(100) {
+            val docs = RandomNumbers.randomIntBetween(random(), 1000, 10000)
+            val expected = generateDocIds(docs, random())
+            val expectedEven = expected.filter(evenPredicate)
+            val expectedOdd = expected.filter(oddPredicate)
+
+            val result = collectAll(ctx, expected, cm)
+            assertTrue(result is List<*>)
+            val intResults = (result as List<Int>).sorted()
+            assertContentEquals((expectedEven + expectedOdd).sorted(), intResults)
+        }
+
+        reader.close()
+        dir.close()
+    }
+
+    @Test
+    fun testEmptyCollectors() {
+        assertFailsWith<IllegalArgumentException> {
+            CompositeCollectorManager(emptyList()).newCollector()
+        }
+    }
+
+    private fun newDirectory(): Directory = ByteBuffersDirectory()
+
+    private fun reader(dir: Directory): DirectoryReader {
+        val iw = IndexWriter(dir, IndexWriterConfig())
+        iw.addDocument(Document())
+        iw.commit()
+        val reader = DirectoryReader.open(dir)
+        iw.close()
+        return reader
+    }
+
+    private fun <C : Collector> collectAll(
+        ctx: LeafReaderContext,
+        values: Collection<Int>,
+        collectorManager: CollectorManager<C, *>
+    ): Any? {
+        val collectors = mutableListOf<C>()
+        var collector = collectorManager.newCollector()
+        collectors.add(collector)
+        var leafCollector = collector.getLeafCollector(ctx)
+        for (v in values) {
+            if (random().nextInt(10) == 1) {
+                collector = collectorManager.newCollector()
+                collectors.add(collector)
+                leafCollector = collector.getLeafCollector(ctx)
+            }
+            leafCollector.collect(v)
+        }
+        return collectorManager.reduce(collectors)
+    }
+
+    private fun generateDocIds(count: Int, random: Random): Set<Int> {
+        val generated = mutableSetOf<Int>()
+        repeat(count) {
+            generated.add(random.nextInt())
+        }
+        return generated
+    }
+
+    private class CompositeCollectorManager(
+        private val predicates: List<(Int) -> Boolean>
+    ) : CollectorManager<Collector, List<Int>> {
+
+        override fun newCollector(): Collector {
+            val collectors = predicates.map { SimpleListCollector(it) }
+            return MultiCollector.wrap(collectors)
+        }
+
+        override fun reduce(collectors: MutableCollection<Collector>): List<Int> {
+            val all = mutableListOf<Int>()
+            for (m in collectors) {
+                for (c in (m as MultiCollector).getCollectors()) {
+                    all.addAll((c as SimpleListCollector).collected)
+                }
+            }
+            return all
+        }
+    }
+
+    private class SimpleListCollector(
+        private val predicate: (Int) -> Boolean
+    ) : Collector {
+        val collected: MutableList<Int> = mutableListOf()
+
+        override fun getLeafCollector(context: LeafReaderContext): LeafCollector {
+            return object : LeafCollector {
+                override fun setScorer(scorer: Scorable) {}
+                override fun collect(doc: Int) {
+                    if (predicate(doc)) {
+                        collected.add(doc)
+                    }
+                }
+            }
+        }
+
+        override fun scoreMode(): ScoreMode {
+            return ScoreMode.COMPLETE
+        }
+
+        override var weight: Weight? = null
+    }
+}
+


### PR DESCRIPTION
## Summary
- port TestCollectorManager unit test
- add minimal MultiCollector implementation to support CollectorManager tests

## Testing
- `./gradlew compileKotlinJvm` *(fails: Trust store file /etc/ssl/certs/java/cacerts does not exist or is not readable)*
- `./gradlew compileTestKotlinJvm` *(fails: Calculating task graph as no cached configuration is available for tasks: compileTestKotlinJvm)*
- `./gradlew jvmTest --tests org.gnit.lucenekmp.search.TestCollectorManager` *(fails: Calculating task graph as no cached configuration is available for tasks: jvmTest --tests org.gnit.lucenekmp.search.TestCollectorManager)*

------
https://chatgpt.com/codex/tasks/task_e_68bf76e6e4a4832b8efd7c5b6a0117b7