### PR TITLE
Port TestPendingDeletes

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -41,7 +41,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.index.TestIndexableField -> org.apache.lucene.index.IndexableField (Ported)
 - org.apache.lucene.index.TestMultiFields -> org.apache.lucene.index.MultiFields (Ported)
 - org.apache.lucene.index.TestOneMergeWrappingMergePolicy -> org.apache.lucene.index.OneMergeWrappingMergePolicy (Ported)
-- org.apache.lucene.index.TestPendingDeletes -> org.apache.lucene.index.PendingDeletes (Ported)
 - org.apache.lucene.index.TestPendingSoftDeletes -> org.apache.lucene.index.PendingSoftDeletes (Ported)
 - org.apache.lucene.index.TestTermVectorsReader -> org.apache.lucene.codecs.TermVectorsReader (Ported)
 - org.apache.lucene.internal.vectorization.TestVectorScorer -> org.apache.lucene.search.VectorScorer (Ported)

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/index/PendingDeletes.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/index/PendingDeletes.kt
@@ -14,18 +14,19 @@ import org.gnit.lucenekmp.util.IOUtils
 /** This class handles accounting and applying pending deletes for live segment readers  */
 open class PendingDeletes(
     val info: SegmentCommitInfo,
-    liveDocs: Bits? = null,
+    initialLiveDocs: Bits? = null,
     liveDocsInitialized: Boolean = !info.hasDeletions()
 ) {
 
     // Read-only live docs, null until live docs are initialized or if all docs are alive
-    var liveDocs: Bits?
+    var liveDocs: Bits? = initialLiveDocs
         /** Returns a snapshot of the current live docs.  */
-        get(): Bits? {
+        get() {
             // Prevent modifications to the returned live docs
             writeableLiveDocs = null
-            return liveDocs
+            return field
         }
+        private set
 
     // Writeable live docs, null if this instance is not ready to accept writes, in which
     // case getMutableBits needs to be called
@@ -42,7 +43,6 @@ open class PendingDeletes(
     }
 
     init {
-        this.liveDocs = liveDocs
         pendingDeleteCount = 0
         this.liveDocsInitialized = liveDocsInitialized
     }

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestPendingDeletes.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestPendingDeletes.kt
@@ -1,0 +1,164 @@
+package org.gnit.lucenekmp.index
+
+import org.gnit.lucenekmp.codecs.Codec
+import org.gnit.lucenekmp.store.ByteBuffersDirectory
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.store.IOContext
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.TestUtil
+import org.gnit.lucenekmp.util.StringHelper
+import org.gnit.lucenekmp.util.Version
+import kotlin.test.*
+
+class TestPendingDeletes : LuceneTestCase() {
+    protected open fun newPendingDeletes(commitInfo: SegmentCommitInfo): PendingDeletes {
+        return PendingDeletes(commitInfo)
+    }
+
+    @Test
+    fun testDeleteDoc() {
+        val dir: Directory = ByteBuffersDirectory()
+        val si = SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "test",
+            10,
+            false,
+            false,
+            Codec.default,
+            mutableMapOf(),
+            StringHelper.randomId(),
+            HashMap(),
+            null
+        )
+        val commitInfo = SegmentCommitInfo(si, 0, 0, -1, -1, -1, StringHelper.randomId())
+        val deletes = newPendingDeletes(commitInfo)
+        assertNull(deletes.liveDocs)
+        val docToDelete = TestUtil.nextInt(random(), 0, 7)
+        assertTrue(deletes.delete(docToDelete))
+        assertNotNull(deletes.liveDocs)
+        assertEquals(1, deletes.numPendingDeletes())
+
+        var liveDocs = deletes.liveDocs
+        assertFalse(liveDocs!!.get(docToDelete))
+        assertFalse(deletes.delete(docToDelete))
+
+        assertTrue(liveDocs.get(8))
+        assertTrue(deletes.delete(8))
+        assertTrue(liveDocs.get(8))
+        assertEquals(2, deletes.numPendingDeletes())
+
+        assertTrue(liveDocs.get(9))
+        assertTrue(deletes.delete(9))
+        assertTrue(liveDocs.get(9))
+
+        liveDocs = deletes.liveDocs
+        assertFalse(liveDocs!!.get(9))
+        assertFalse(liveDocs.get(8))
+        assertFalse(liveDocs.get(docToDelete))
+        assertEquals(3, deletes.numPendingDeletes())
+        dir.close()
+    }
+
+    @Test
+    fun testWriteLiveDocs() {
+        val dir: Directory = ByteBuffersDirectory()
+        val si = SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "test",
+            6,
+            false,
+            false,
+            Codec.default,
+            mutableMapOf(),
+            StringHelper.randomId(),
+            HashMap(),
+            null
+        )
+        val commitInfo = SegmentCommitInfo(si, 0, 0, -1, -1, -1, StringHelper.randomId())
+        val deletes = newPendingDeletes(commitInfo)
+        assertFalse(deletes.writeLiveDocs(dir))
+        assertEquals(0, dir.listAll().size)
+        val secondDocDeletes = random().nextBoolean()
+        deletes.delete(5)
+        if (secondDocDeletes) {
+            deletes.liveDocs
+            deletes.delete(2)
+        }
+        assertEquals(-1L, commitInfo.delGen)
+        assertEquals(0, commitInfo.delCount)
+
+        assertEquals(if (secondDocDeletes) 2 else 1, deletes.numPendingDeletes())
+        assertTrue(deletes.writeLiveDocs(dir))
+        assertEquals(1, dir.listAll().size)
+        var liveDocs = Codec.default.liveDocsFormat().readLiveDocs(dir, commitInfo, IOContext.DEFAULT)
+        assertFalse(liveDocs.get(5))
+        if (secondDocDeletes) {
+            assertFalse(liveDocs.get(2))
+        } else {
+            assertTrue(liveDocs.get(2))
+        }
+        assertTrue(liveDocs.get(0))
+        assertTrue(liveDocs.get(1))
+        assertTrue(liveDocs.get(3))
+        assertTrue(liveDocs.get(4))
+
+        assertEquals(0, deletes.numPendingDeletes())
+        assertEquals(if (secondDocDeletes) 2 else 1, commitInfo.delCount)
+        assertEquals(1L, commitInfo.delGen)
+
+        deletes.delete(0)
+        assertTrue(deletes.writeLiveDocs(dir))
+        assertEquals(2, dir.listAll().size)
+        liveDocs = Codec.default.liveDocsFormat().readLiveDocs(dir, commitInfo, IOContext.DEFAULT)
+        assertFalse(liveDocs.get(5))
+        if (secondDocDeletes) {
+            assertFalse(liveDocs.get(2))
+        } else {
+            assertTrue(liveDocs.get(2))
+        }
+        assertFalse(liveDocs.get(0))
+        assertTrue(liveDocs.get(1))
+        assertTrue(liveDocs.get(3))
+        assertTrue(liveDocs.get(4))
+
+        assertEquals(0, deletes.numPendingDeletes())
+        assertEquals(if (secondDocDeletes) 3 else 2, commitInfo.delCount)
+        assertEquals(2L, commitInfo.delGen)
+        dir.close()
+    }
+
+    @Test
+    fun testIsFullyDeleted() {
+        val dir: Directory = ByteBuffersDirectory()
+        val si = SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "test",
+            3,
+            false,
+            false,
+            Codec.default,
+            mutableMapOf(),
+            StringHelper.randomId(),
+            HashMap(),
+            null
+        )
+        val commitInfo = SegmentCommitInfo(si, 0, 0, -1, -1, -1, StringHelper.randomId())
+        val fieldInfos = FieldInfos.EMPTY
+        si.codec.fieldInfosFormat().write(dir, si, "", fieldInfos, IOContext.DEFAULT)
+        val deletes = newPendingDeletes(commitInfo)
+        for (i in 0 until 3) {
+            assertTrue(deletes.delete(i))
+            if (random().nextBoolean()) {
+                assertTrue(deletes.writeLiveDocs(dir))
+            }
+            assertEquals(i == 2, deletes.isFullyDeleted { null as CodecReader })
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Kotlin test TestPendingDeletes verifying delete tracking and live docs persistence
- fix PendingDeletes liveDocs getter to avoid recursion
- update TODO_TEST registry

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.index.TestPendingDeletes`


------
https://chatgpt.com/codex/tasks/task_e_68bf7798d1f0832bb006e735fbc26fa0