### PR TITLE
Add skeleton for TestDirectoryReader

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestDirectoryReader.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestDirectoryReader.kt
@@ -1,0 +1,177 @@
+package org.gnit.lucenekmp.index
+
+import org.gnit.lucenekmp.document.Document
+import org.gnit.lucenekmp.tests.index.DocHelper
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TestDirectoryReader : LuceneTestCase() {
+
+    @Test
+    fun testDocument() {
+        val dir = newDirectory()
+        val doc1 = Document()
+        val doc2 = Document()
+        DocHelper.setupDoc(doc1)
+        DocHelper.setupDoc(doc2)
+        DocHelper.writeDoc(random(), dir, doc1)
+        DocHelper.writeDoc(random(), dir, doc2)
+        val reader = DirectoryReader.open(dir)
+        assertTrue(reader is StandardDirectoryReader)
+        val storedFields = reader.storedFields()
+
+        val newDoc1 = storedFields.document(0)
+        assertNotNull(newDoc1)
+        assertEquals(
+            DocHelper.numFields(doc1) - DocHelper.unstored.size,
+            DocHelper.numFields(newDoc1)
+        )
+        val newDoc2 = storedFields.document(1)
+        assertNotNull(newDoc2)
+        assertEquals(
+            DocHelper.numFields(doc2) - DocHelper.unstored.size,
+            DocHelper.numFields(newDoc2)
+        )
+        val vector = reader.termVectors().get(0).terms(DocHelper.TEXT_FIELD_2_KEY)
+        assertNotNull(vector)
+
+        reader.close()
+        dir.close()
+    }
+
+    @Test
+    fun testMultiTermDocs() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testIsCurrent() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testGetFieldNames() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testTermVectors() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testBinaryFields() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testOpenEmptyDirectory() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testFilesOpenClose() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testOpenReaderAfterDelete() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testGetIndexCommit() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testNoDir() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testNoDupCommitFileNames() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testUniqueTermCount() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testPrepareCommitIsCurrent() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testListCommits() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testTotalTermFreqCached() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testGetSumDocFreq() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testGetDocCount() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testGetSumTotalTermFreq() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testReaderFinishedListener() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testOOBDocID() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testTryIncRef() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testStressTryIncRef() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testLoadCertainFields() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testIndexExistsOnNonExistentDirectory() {
+        // TODO: Port this test
+    }
+
+    @Test
+    fun testOpenWithInvalidMinCompatVersion() {
+        // TODO: Port this test
+    }
+
+    // Placeholder for IncThread inner class
+    class IncThread {
+        fun run() {
+            // TODO: Port this class
+        }
+    }
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/index/DocHelper.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/index/DocHelper.kt
@@ -1,0 +1,74 @@
+package org.gnit.lucenekmp.tests.index
+
+import org.gnit.lucenekmp.analysis.Analyzer
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.document.Document
+import org.gnit.lucenekmp.document.Field
+import org.gnit.lucenekmp.document.FieldType
+import org.gnit.lucenekmp.document.TextField
+import org.gnit.lucenekmp.index.IndexWriter
+import org.gnit.lucenekmp.index.IndexWriterConfig
+import org.gnit.lucenekmp.index.IndexableField
+import org.gnit.lucenekmp.search.IndexSearcher
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.tests.analysis.MockTokenizer
+import kotlin.random.Random
+
+/** Helper functions for tests that handles documents */
+object DocHelper {
+    const val TEXT_FIELD_1_KEY = "textField1"
+    const val FIELD_1_TEXT = "field one text"
+    val textField1 = TextField(TEXT_FIELD_1_KEY, FIELD_1_TEXT, Field.Store.YES)
+
+    const val TEXT_FIELD_2_KEY = "textField2"
+    const val FIELD_2_TEXT = "field field field two text"
+    val TEXT_TYPE_STORED_WITH_TVS = FieldType(TextField.TYPE_STORED).apply {
+        setStoreTermVectors(true)
+        setStoreTermVectorPositions(true)
+        setStoreTermVectorOffsets(true)
+        freeze()
+    }
+    val textField2 = Field(TEXT_FIELD_2_KEY, FIELD_2_TEXT, TEXT_TYPE_STORED_WITH_TVS)
+
+    const val UNSTORED_FIELD_1_KEY = "unstored1"
+    private const val UNSTORED_1_FIELD_TEXT = "unstored field 1"
+    val unstoredField1 = TextField(UNSTORED_FIELD_1_KEY, UNSTORED_1_FIELD_TEXT, Field.Store.NO)
+
+    const val UNSTORED_FIELD_2_KEY = "unstored2"
+    private const val UNSTORED_2_FIELD_TEXT = "unstored field 2"
+    val unstoredField2 = TextField(UNSTORED_FIELD_2_KEY, UNSTORED_2_FIELD_TEXT, Field.Store.NO)
+
+    private val fields = arrayOf<IndexableField>(textField1, textField2, unstoredField1, unstoredField2)
+
+    val unstored: MutableMap<String, IndexableField> = mutableMapOf(
+        UNSTORED_FIELD_1_KEY to unstoredField1,
+        UNSTORED_FIELD_2_KEY to unstoredField2
+    )
+
+    fun setupDoc(doc: Document) {
+        for (f in fields) {
+            doc.add(f)
+        }
+    }
+
+    fun writeDoc(random: Random, dir: Directory, doc: Document) {
+        val analyzer = object : Analyzer(PER_FIELD_REUSE_STRATEGY) {
+            override fun createComponents(fieldName: String): TokenStreamComponents {
+                val tokenizer = MockTokenizer(MockTokenizer.WHITESPACE, true)
+                return TokenStreamComponents(tokenizer)
+            }
+
+            override fun normalize(fieldName: String, `in`: TokenStream): TokenStream {
+                return `in`
+            }
+        }
+        val writer = IndexWriter(dir, IndexWriterConfig(analyzer).setSimilarity(IndexSearcher.getDefaultSimilarity()))
+        writer.addDocument(doc)
+        writer.commit()
+        writer.close()
+    }
+
+    fun numFields(doc: Document): Int {
+        return doc.getFields().size
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold TestDirectoryReader with placeholder tests for future porting
- add DocHelper test utility and port `testDocument`

## Testing
- `./gradlew test-framework:compileKotlinJvm core:compileKotlinJvm --offline --console=plain` *(fails: trust store file /etc/ssl/certs/java/cacerts does not exist)*
- `./gradlew core:jvmTest --tests org.gnit.lucenekmp.index.TestDirectoryReader.testDocument --offline --console=plain` *(fails: trust store file /etc/ssl/certs/java/cacerts does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68beebb61f7c832bba522bc187290d5e