### PR TITLE
Stabilize ThreadPoolExecutorTest to fix CI flakiness (fixes #197)

### DIFF
--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ThreadPoolExecutorTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/jdkport/ThreadPoolExecutorTest.kt
@@ -37,7 +37,7 @@ class ThreadPoolExecutorTest {
             logger.debug { "[TEST] execute_runsTask: submitted; queueSize(afterSubmit)=${queue.size}; awaiting result..." }
             val v = try {
                 logger.debug { "[TEST] execute_runsTask: about to await result (withTimeout)" }
-                withTimeout(1500) { result.await() }.also {
+                withTimeout(5000) { result.await() }.also {
                     logger.debug { "[TEST] execute_runsTask: await returned value=$it" }
                 }
             } catch (t: TimeoutCancellationException) {
@@ -60,6 +60,8 @@ class ThreadPoolExecutorTest {
     fun submit_runnableAndCallable() = runBlocking {
         val exec = newExecutor()
         try {
+            // Proactively start a core worker to reduce scheduler jitter on CI
+            exec.prestartCoreThread()
             logger.debug { "[TEST] submit_runnableAndCallable: submitting tasks" }
             val f1 = exec.submit {
                 logger.debug { "[TEST] submit_runnableAndCallable: runnable ran" }
@@ -67,9 +69,9 @@ class ThreadPoolExecutorTest {
             val f2 = exec.submit(Callable {
                 logger.debug { "[TEST] submit_runnableAndCallable: callable ran" }; 7 })
             logger.debug { "[TEST] submit_runnableAndCallable: submitted; awaiting f1" }
-            withTimeout(2000) { f1.get() }
+            withTimeout(5000) { f1.get() }
             logger.debug { "[TEST] submit_runnableAndCallable: f1 done awaiting f2" }
-            val v = withTimeout(2000) { f2.get() }
+            val v = withTimeout(5000) { f2.get() }
             logger.debug { "[TEST] submit_runnableAndCallable: f2 done value=$v" }
             assertEquals(7, v)
         } finally {


### PR DESCRIPTION
Summary
- Stabilizes ThreadPoolExecutorTest which intermittently timed out on CI with TimeoutCancellationException.
- Changes are test-only and do not alter production executor semantics.

Changes
- Prestart a core worker before submitting tasks in submit_runnableAndCallable via exec.prestartCoreThread().
- Increase withTimeout budgets from 1.5s/2s to 5s in execute_runsTask and submit_runnableAndCallable.

Root Cause
- The port runs pool “threads” as coroutines (Job) on the DefaultDispatcher. Under CI load, coroutine scheduling, worker startup (GlobalScope.launch in the default ThreadFactory), and runWorker→getTask() handoff can exceed 2s.
- The test wrapped Future.get() with withTimeout(2000). When the worker hadn’t yet started or reached getTask() due to scheduling jitter, get() legitimately waited longer and withTimeout threw TimeoutCancellationException even though the executor behaved correctly.

Why This Fix Works
- Prestarting a core worker removes cold-start latency (thread creation + dispatcher scheduling + entering getTask()), ensuring a worker is already waiting on the queue when tasks are submitted.
- Increasing the timeout to 5s tolerates normal CI variance without masking real deadlocks or logic bugs. Typical execution is still milliseconds; the larger budget only absorbs scheduler jitter.

Validation
- Ran targeted JVM test: :core:jvmTest --tests "org.gnit.lucenekmp.jdkport.ThreadPoolExecutorTest"; all tests passed locally.

Notes
- No behavior change to ThreadPoolExecutor implementation.
- If desired, we could tighten logging or add a shorter timeout when running outside CI, but this change keeps test stability simple and explicit.

Fixes #197