### PR TITLE
Port TestFieldInvertState

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -31,7 +31,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.index.TestCachingMergeContext -> org.apache.lucene.index.CachingMergeContext (Ported)
 - org.apache.lucene.index.TestDirectoryReader -> org.apache.lucene.index.DirectoryReader (Ported)
 - org.apache.lucene.index.TestDocumentsWriterStallControl -> org.apache.lucene.index.DocumentsWriterStallControl (Ported)
-- org.apache.lucene.index.TestFieldInvertState -> org.apache.lucene.index.FieldInvertState (Ported)
 - org.apache.lucene.index.TestFlushByRamOrCountsPolicy -> org.apache.lucene.index.FlushByRamOrCountsPolicy (Ported)
 - org.apache.lucene.index.TestIndexCommit -> org.apache.lucene.index.IndexCommit (Ported)
 - org.apache.lucene.index.TestIndexWriter -> org.apache.lucene.index.IndexWriter (Ported)

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/tokenattributes/FlagsAttribute.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/tokenattributes/FlagsAttribute.kt
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gnit.lucenekmp.analysis.tokenattributes
+
+import org.gnit.lucenekmp.util.Attribute
+
+/**
+ * This attribute can be used to pass different flags down the tokenizer chain.
+ *
+ * It is completely distinct from [TypeAttribute]; the flags can encode
+ * information about the token for use by other token filters.
+ */
+interface FlagsAttribute : Attribute {
+    /** Bitset for any flags that have been set. */
+    var flags: Int
+}
+

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/tokenattributes/FlagsAttributeImpl.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/tokenattributes/FlagsAttributeImpl.kt
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gnit.lucenekmp.analysis.tokenattributes
+
+import org.gnit.lucenekmp.util.AttributeImpl
+import org.gnit.lucenekmp.util.AttributeReflector
+
+/** Default implementation of [FlagsAttribute]. */
+class FlagsAttributeImpl : AttributeImpl(), FlagsAttribute {
+    override var flags: Int = 0
+
+    override fun clear() {
+        flags = 0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is FlagsAttributeImpl && other.flags == flags
+    }
+
+    override fun hashCode(): Int {
+        return flags
+    }
+
+    override fun copyTo(target: AttributeImpl) {
+        (target as FlagsAttribute).flags = flags
+    }
+
+    override fun reflectWith(reflector: AttributeReflector) {
+        reflector.reflect(FlagsAttribute::class, "flags", flags)
+    }
+
+    override fun newInstance(): AttributeImpl {
+        throw UnsupportedOperationException(
+            "FlagsAttributeImpl cannot be instantiated directly, use init() instead"
+        )
+    }
+}
+

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/tokenattributes/PackedTokenAttributeImpl.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/analysis/tokenattributes/PackedTokenAttributeImpl.kt
@@ -17,7 +17,7 @@ import org.gnit.lucenekmp.util.AttributeReflector
  *  * [TermFrequencyAttribute]
  *
  */
-class PackedTokenAttributeImpl
+open class PackedTokenAttributeImpl
 /** Constructs the attribute implementation.  */
     : CharTermAttributeImpl(), TypeAttribute, PositionIncrementAttribute, PositionLengthAttribute, OffsetAttribute,
     TermFrequencyAttribute {

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/similarities/Similarity.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/similarities/Similarity.kt
@@ -131,7 +131,7 @@ abstract class Similarity
      * @param state accumulated state of term processing for this field
      * @return computed norm value
      */
-    fun computeNorm(state: FieldInvertState): Long {
+    open fun computeNorm(state: FieldInvertState): Long {
         val numTerms: Int
         if (state.indexOptions === IndexOptions.DOCS) {
             numTerms = state.uniqueTermCount

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/AttributeFactory.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/AttributeFactory.kt
@@ -2,6 +2,8 @@ package org.gnit.lucenekmp.util
 
 import org.gnit.lucenekmp.analysis.tokenattributes.CharTermAttribute
 import org.gnit.lucenekmp.analysis.tokenattributes.CharTermAttributeImpl
+import org.gnit.lucenekmp.analysis.tokenattributes.FlagsAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.FlagsAttributeImpl
 import org.gnit.lucenekmp.analysis.tokenattributes.OffsetAttribute
 import org.gnit.lucenekmp.analysis.tokenattributes.OffsetAttributeImpl
 import org.gnit.lucenekmp.analysis.tokenattributes.PackedTokenAttributeImpl
@@ -22,6 +24,7 @@ abstract class AttributeFactory {
                 CharTermAttribute::class -> CharTermAttributeImpl()
                 OffsetAttribute::class -> OffsetAttributeImpl()
                 PayloadAttribute::class -> PayloadAttributeImpl()
+                FlagsAttribute::class -> FlagsAttributeImpl()
                 else -> throw IllegalArgumentException(
                     "Cannot find implementing class for: ${attClass.qualifiedName}"
                 )
@@ -79,6 +82,7 @@ abstract class AttributeFactory {
                 CharTermAttributeImpl::class -> { { CharTermAttributeImpl() } }
                 OffsetAttributeImpl::class -> { { OffsetAttributeImpl() } }
                 PayloadAttributeImpl::class -> { { PayloadAttributeImpl() } }
+                FlagsAttributeImpl::class -> { { FlagsAttributeImpl() } }
                 else -> throw IllegalArgumentException("No known no-arg constructor for ${clazz.qualifiedName}")
             }
         }

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/AttributeReflector.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/AttributeReflector.kt
@@ -13,5 +13,5 @@ fun interface AttributeReflector {
      * method once using `org.apache.lucene.analysis.tokenattributes.CharTermAttribute.class` as
      * attribute class, `"term"` as key and the actual value as a String.
      */
-    fun reflect(attClass: KClass<out Attribute>, key: String, value: Any)
+    fun reflect(attClass: KClass<out Attribute>, key: String, value: Any?)
 }

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/AttributeSource.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/AttributeSource.kt
@@ -349,7 +349,7 @@ open class AttributeSource {
         val buffer = StringBuilder()
         reflectWith(
             object : AttributeReflector {
-                override fun reflect(attClass: KClass<out Attribute>, key: String, value: Any) {
+                override fun reflect(attClass: KClass<out Attribute>, key: String, value: Any?) {
                     if (buffer.length > 0) {
                         buffer.append(',')
                     }

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestFieldInvertState.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestFieldInvertState.kt
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gnit.lucenekmp.index
+
+import org.gnit.lucenekmp.document.Document
+import org.gnit.lucenekmp.document.Field
+import org.gnit.lucenekmp.document.TextField
+import org.gnit.lucenekmp.index.IndexWriter
+import org.gnit.lucenekmp.index.IndexWriterConfig
+import org.gnit.lucenekmp.search.CollectionStatistics
+import org.gnit.lucenekmp.search.TermStatistics
+import org.gnit.lucenekmp.search.similarities.Similarity
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.store.ByteBuffersDirectory
+import org.gnit.lucenekmp.tests.analysis.CannedTokenStream
+import org.gnit.lucenekmp.tests.analysis.MockAnalyzer
+import org.gnit.lucenekmp.tests.analysis.Token
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.TestUtil
+import org.gnit.lucenekmp.util.IOUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestFieldInvertState : LuceneTestCase() {
+
+    /** Similarity holds onto the FieldInvertState for subsequent verification. */
+    private class NeverForgetsSimilarity : Similarity() {
+        var lastState: FieldInvertState? = null
+
+        override fun computeNorm(state: FieldInvertState): Long {
+            lastState = state
+            return 1
+        }
+
+        override fun scorer(
+            boost: Float,
+            collectionStats: CollectionStatistics,
+            vararg termStats: TermStatistics
+        ): SimScorer {
+            throw UnsupportedOperationException()
+        }
+
+        companion object {
+            val INSTANCE = NeverForgetsSimilarity()
+        }
+    }
+
+    @Test
+    fun testBasic() {
+        val dir: Directory = newDirectory()
+        val iwc = IndexWriterConfig(MockAnalyzer(random()))
+        iwc.similarity = NeverForgetsSimilarity.INSTANCE
+        val w = IndexWriter(dir, iwc)
+        val doc = Document()
+        val field = Field(
+            "field",
+            CannedTokenStream(
+                Token("a", 0, 1),
+                Token("b", 2, 3),
+                Token("c", 4, 5)
+            ),
+            TextField.TYPE_NOT_STORED
+        )
+        doc.add(field)
+        w.addDocument(doc)
+        val fis = NeverForgetsSimilarity.INSTANCE.lastState!!
+        assertEquals(1, fis.maxTermFrequency)
+        assertEquals(3, fis.uniqueTermCount)
+        assertEquals(0, fis.numOverlap)
+        assertEquals(3, fis.length)
+        IOUtils.close(w, dir)
+    }
+
+    @Test
+    fun testRandom() {
+        val numUniqueTokens = TestUtil.nextInt(random(), 1, 25)
+        val dir: Directory = newDirectory()
+        val iwc = IndexWriterConfig(MockAnalyzer(random()))
+        iwc.similarity = NeverForgetsSimilarity.INSTANCE
+        val w = IndexWriter(dir, iwc)
+        val doc = Document()
+
+        val numTokens = atLeast(10000)
+        val tokens = Array(numTokens) { Token() }
+        val counts = mutableMapOf<Char, Int>()
+        var numStacked = 0
+        var maxTermFreq = 0
+        var pos = -1
+        for (i in 0 until numTokens) {
+            val tokenChar = ('a'.code + random().nextInt(numUniqueTokens)).toChar()
+            val oldCount = counts[tokenChar]
+            val newCount = if (oldCount == null) 1 else 1 + oldCount
+            counts[tokenChar] = newCount
+            maxTermFreq = maxOf(maxTermFreq, newCount)
+
+            val token = Token(tokenChar.toString(), 2 * i, 2 * i + 1)
+            if (i > 0 && random().nextInt(7) == 3) {
+                token.setPositionIncrement(0)
+                numStacked++
+            } else {
+                pos++
+            }
+            tokens[i] = token
+        }
+
+        val field = Field("field", CannedTokenStream(*tokens), TextField.TYPE_NOT_STORED)
+        doc.add(field)
+        w.addDocument(doc)
+        val fis = NeverForgetsSimilarity.INSTANCE.lastState!!
+        assertEquals(maxTermFreq, fis.maxTermFrequency)
+        assertEquals(counts.size, fis.uniqueTermCount)
+        assertEquals(numStacked, fis.numOverlap)
+        assertEquals(numTokens, fis.length)
+        assertEquals(pos, fis.position)
+
+        IOUtils.close(w, dir)
+    }
+
+    private fun newDirectory(): Directory = ByteBuffersDirectory()
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/analysis/CannedTokenStream.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/analysis/CannedTokenStream.kt
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gnit.lucenekmp.tests.analysis
+
+import org.gnit.lucenekmp.analysis.TokenStream
+import org.gnit.lucenekmp.analysis.tokenattributes.OffsetAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.PositionIncrementAttribute
+
+/** TokenStream from a canned list of Tokens. */
+class CannedTokenStream : TokenStream {
+    private val tokens: Array<out Token>
+    private var upto = 0
+    private val offsetAtt: OffsetAttribute
+    private val posIncrAtt: PositionIncrementAttribute
+    private val finalOffset: Int
+    private val finalPosInc: Int
+    private val tokenAtt: Token
+
+    constructor(vararg tokens: Token) : this(0, 0, *tokens)
+
+    /** If you want trailing holes, pass a non-zero finalPosInc. */
+    constructor(finalPosInc: Int, finalOffset: Int, vararg tokens: Token) :
+        super(Token.TOKEN_ATTRIBUTE_FACTORY) {
+        this.tokens = tokens
+        this.finalOffset = finalOffset
+        this.finalPosInc = finalPosInc
+        offsetAtt = addAttribute(OffsetAttribute::class)
+        posIncrAtt = addAttribute(PositionIncrementAttribute::class)
+        tokenAtt = offsetAtt as Token
+    }
+
+    override fun end() {
+        super.end()
+        posIncrAtt.setPositionIncrement(finalPosInc)
+        offsetAtt.setOffset(finalOffset, finalOffset)
+    }
+
+    override fun reset() {
+        super.reset()
+        upto = 0
+    }
+
+    override fun incrementToken(): Boolean {
+        return if (upto < tokens.size) {
+            clearAttributes()
+            tokens[upto++].copyTo(tokenAtt)
+            true
+        } else {
+            false
+        }
+    }
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/analysis/Token.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/analysis/Token.kt
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gnit.lucenekmp.tests.analysis
+
+import kotlin.reflect.KClass
+import org.gnit.lucenekmp.analysis.tokenattributes.FlagsAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.PackedTokenAttributeImpl
+import org.gnit.lucenekmp.analysis.tokenattributes.PayloadAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.CharTermAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.TypeAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.PositionIncrementAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.PositionLengthAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.OffsetAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.TermFrequencyAttribute
+import org.gnit.lucenekmp.analysis.tokenattributes.TermToBytesRefAttribute
+import org.gnit.lucenekmp.util.Attribute
+import org.gnit.lucenekmp.util.AttributeFactory
+import org.gnit.lucenekmp.util.AttributeImpl
+import org.gnit.lucenekmp.util.AttributeReflector
+import org.gnit.lucenekmp.util.BytesRef
+
+/**
+ * A Token is an occurrence of a term from the text of a field. It consists of the
+ * term's text, start and end offsets, and optionally flags and payload.
+ */
+class Token() : PackedTokenAttributeImpl(), FlagsAttribute, PayloadAttribute {
+    override var flags: Int = 0
+    override var payload: BytesRef? = null
+
+    constructor(text: CharSequence, start: Int, end: Int) : this() {
+        append(text)
+        setOffset(start, end)
+    }
+
+    constructor(text: CharSequence, posInc: Int, start: Int, end: Int) : this(text, start, end) {
+        setPositionIncrement(posInc)
+    }
+
+    constructor(text: CharSequence, posInc: Int, start: Int, end: Int, posLength: Int) :
+        this(text, posInc, start, end) {
+        positionLength = posLength
+    }
+
+    override fun clear() {
+        super.clear()
+        flags = 0
+        payload = null
+    }
+
+    override fun clone(): Token {
+        val t = super.clone() as Token
+        if (payload != null) {
+            t.payload = BytesRef.deepCopyOf(payload!!)
+        }
+        return t
+    }
+
+    /**
+     * Copy the prototype token's fields into this one. Payloads are shared.
+     */
+    fun reinit(prototype: Token) {
+        prototype.copyToWithoutPayloadClone(this)
+    }
+
+    private fun copyToWithoutPayloadClone(target: AttributeImpl) {
+        super.copyTo(target)
+        (target as FlagsAttribute).flags = flags
+        (target as PayloadAttribute).payload = payload
+    }
+
+    override fun copyTo(target: AttributeImpl) {
+        super.copyTo(target)
+        (target as FlagsAttribute).flags = flags
+        (target as PayloadAttribute).payload = payload?.let { BytesRef.deepCopyOf(it) }
+    }
+
+    override fun reflectWith(reflector: AttributeReflector) {
+        super.reflectWith(reflector)
+        reflector.reflect(FlagsAttribute::class, "flags", flags)
+        reflector.reflect(PayloadAttribute::class, "payload", payload)
+    }
+
+    companion object {
+        val TOKEN_ATTRIBUTE_FACTORY: AttributeFactory = object : AttributeFactory() {
+            private var tokenImpl: Token? = null
+            override fun createAttributeInstance(attClass: KClass<out Attribute>): AttributeImpl {
+                val token = tokenImpl ?: Token().also { tokenImpl = it }
+                return when (attClass) {
+                    FlagsAttribute::class,
+                    PayloadAttribute::class,
+                    CharTermAttribute::class,
+                    TypeAttribute::class,
+                    PositionIncrementAttribute::class,
+                    PositionLengthAttribute::class,
+                    OffsetAttribute::class,
+                    TermFrequencyAttribute::class,
+                    TermToBytesRefAttribute::class -> token
+                    else -> AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY.createAttributeInstance(attClass)
+                }
+            }
+        }
+    }
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/util/TestUtil.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/util/TestUtil.kt
@@ -1458,7 +1458,7 @@ class TestUtil {
             att: AttributeImpl, reflectedValues: MutableMap<String, T>
         ) {
             val map: MutableMap<String, T> = HashMap()
-            att.reflectWith { attClass: KClass<out Attribute>, key: String, value: Any ->
+            att.reflectWith { attClass: KClass<out Attribute>, key: String, value: Any? ->
                 map.put(
                     attClass.simpleName + '#' + key,
                     value as T


### PR DESCRIPTION
## Summary
- add FlagsAttribute and implementation for test token utilities
- introduce Token and CannedTokenStream helpers for analysis tests
- port TestFieldInvertState to verify term inversion stats

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew compileKotlinLinuxX64`
- `./gradlew compileTestKotlinLinuxX64`
- `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.index.TestFieldInvertState`
- `./gradlew jvmTest`
- `./gradlew allTests` *(fails: Failed to find Build Tools revision 35.0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68bfcdd8b64c832b806a6b33879c06e2