### PR TITLE
Port TestIndexCommit test

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -33,7 +33,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.index.TestDocumentsWriterStallControl -> org.apache.lucene.index.DocumentsWriterStallControl (Ported)
 - org.apache.lucene.index.TestFieldInvertState -> org.apache.lucene.index.FieldInvertState (Ported)
 - org.apache.lucene.index.TestFlushByRamOrCountsPolicy -> org.apache.lucene.index.FlushByRamOrCountsPolicy (Ported)
-- org.apache.lucene.index.TestIndexCommit -> org.apache.lucene.index.IndexCommit (Ported)
 - org.apache.lucene.index.TestIndexWriter -> org.apache.lucene.index.IndexWriter (Ported)
 - org.apache.lucene.index.TestIndexWriterConfig -> org.apache.lucene.index.IndexWriterConfig (Ported)
 - org.apache.lucene.index.TestIndexableField -> org.apache.lucene.index.IndexableField (Ported)

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestIndexCommit.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/index/TestIndexCommit.kt
@@ -1,0 +1,41 @@
+package org.gnit.lucenekmp.index
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.gnit.lucenekmp.store.Directory
+import org.gnit.lucenekmp.store.ByteBuffersDirectory
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+
+class TestIndexCommit : LuceneTestCase() {
+
+    @Test
+    fun testEqualsHashCode() {
+        newDirectory().use { dir ->
+            val ic1 = object : IndexCommit() {
+                override val segmentsFileName: String? = "a"
+                override val directory: Directory = dir
+                override val fileNames: MutableCollection<String> = mutableListOf()
+                override fun delete() {}
+                override val generation: Long = 0
+                override val userData: MutableMap<String, String> = mutableMapOf()
+                override val isDeleted: Boolean = false
+                override val segmentCount: Int = 2
+            }
+            val ic2 = object : IndexCommit() {
+                override val segmentsFileName: String? = "b"
+                override val directory: Directory = dir
+                override val fileNames: MutableCollection<String> = mutableListOf()
+                override fun delete() {}
+                override val generation: Long = 0
+                override val userData: MutableMap<String, String> = mutableMapOf()
+                override val isDeleted: Boolean = false
+                override val segmentCount: Int = 2
+            }
+            assertEquals(ic1, ic2)
+            assertEquals(ic1.hashCode(), ic2.hashCode(), "hash codes are not equals")
+        }
+    }
+
+    private fun newDirectory(): Directory = ByteBuffersDirectory()
+}
+


### PR DESCRIPTION
## Summary
- port IndexCommit equality test to Kotlin common test suite
- update TODO_TEST.md to reflect ported test

## Testing
- ⚠️ `./gradlew :core:compileKotlinJvm --stacktrace --no-daemon --console=plain` (trust store missing: build could not complete)
- ⚠️ `./gradlew :core:jvmTest --tests org.gnit.lucenekmp.index.TestIndexCommit --stacktrace --no-daemon --console=plain` (trust store missing: build could not complete)


------
https://chatgpt.com/codex/tasks/task_e_68bfce291600832ba664a7d3f81acc03