### PR TITLE
Port TestReqExclBulkScorer and add RandomApproximationQuery

### DIFF
--- a/TODO_TEST.md
+++ b/TODO_TEST.md
@@ -49,7 +49,6 @@ From PROGRESS2.md → Progress Table for Unit Test Classes:
 - org.apache.lucene.search.TestKnnByteVectorQuery -> org.apache.lucene.search.KnnByteVectorQuery (Ported)
 - org.apache.lucene.search.TestKnnFloatVectorQuery -> org.apache.lucene.search.KnnFloatVectorQuery (Ported)
 - org.apache.lucene.search.TestMatchesIterator -> org.apache.lucene.search.MatchesIterator (Ported)
-- org.apache.lucene.search.TestReqExclBulkScorer -> org.apache.lucene.search.ReqExclBulkScorer (Ported)
 - org.apache.lucene.search.TestTermScorer -> org.apache.lucene.search.TermScorer (Ported)
 - org.apache.lucene.search.TestTopDocsCollector -> org.apache.lucene.search.TopDocsCollector (Ported)
 - org.apache.lucene.search.TestVectorScorer -> org.apache.lucene.search.VectorScorer (Ported)

--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/FilterWeight.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/search/FilterWeight.kt
@@ -1,0 +1,41 @@
+package org.gnit.lucenekmp.search
+
+import okio.IOException
+import org.gnit.lucenekmp.index.LeafReaderContext
+
+/**
+ * A [FilterWeight] contains another [Weight] and implements all abstract methods by
+ * delegating to the wrapped weight.
+ *
+ * Note that [FilterWeight] does not override the non-abstract [Weight.bulkScorer] method
+ * and subclasses must provide their own implementation if required.
+ *
+ * @lucene.internal
+ */
+abstract class FilterWeight protected constructor(
+    query: Query,
+    protected val `in`: Weight
+) : Weight(query) {
+
+    protected constructor(weight: Weight) : this(weight.query, weight)
+
+    override fun isCacheable(ctx: LeafReaderContext): Boolean {
+        return `in`.isCacheable(ctx)
+    }
+
+    @Throws(IOException::class)
+    override fun explain(context: LeafReaderContext, doc: Int): Explanation {
+        return `in`.explain(context, doc)
+    }
+
+    @Throws(IOException::class)
+    override fun matches(context: LeafReaderContext, doc: Int): Matches? {
+        return `in`.matches(context, doc)
+    }
+
+    @Throws(IOException::class)
+    override fun scorerSupplier(context: LeafReaderContext): ScorerSupplier? {
+        return `in`.scorerSupplier(context)
+    }
+}
+

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestReqExclBulkScorer.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/search/TestReqExclBulkScorer.kt
@@ -1,0 +1,114 @@
+package org.gnit.lucenekmp.search
+
+import org.gnit.lucenekmp.tests.search.RandomApproximationQuery.RandomTwoPhaseView
+import org.gnit.lucenekmp.tests.util.LuceneTestCase
+import org.gnit.lucenekmp.tests.util.TestUtil
+import org.gnit.lucenekmp.util.Bits
+import org.gnit.lucenekmp.util.DocIdSetBuilder
+import org.gnit.lucenekmp.util.FixedBitSet
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
+
+class TestReqExclBulkScorer : LuceneTestCase() {
+
+    @Test
+    fun testRandom() {
+        val iters = atLeast(10)
+        for (iter in 0 until iters) {
+            doTestRandom(false)
+        }
+    }
+
+    @Test
+    fun testRandomTwoPhase() {
+        val iters = atLeast(10)
+        for (iter in 0 until iters) {
+            doTestRandom(true)
+        }
+    }
+
+    @Throws(okio.IOException::class)
+    private fun doTestRandom(twoPhase: Boolean) {
+        val maxDoc = TestUtil.nextInt(random(), 1, 1000)
+        val reqBuilder = DocIdSetBuilder(maxDoc)
+        val exclBuilder = DocIdSetBuilder(maxDoc)
+        val numIncludedDocs = TestUtil.nextInt(random(), 1, maxDoc)
+        val numExcludedDocs = TestUtil.nextInt(random(), 1, maxDoc)
+        val reqAdder = reqBuilder.grow(numIncludedDocs)
+        for (i in 0 until numIncludedDocs) {
+            reqAdder.add(random().nextInt(maxDoc))
+        }
+        val exclAdder = exclBuilder.grow(numExcludedDocs)
+        for (i in 0 until numExcludedDocs) {
+            exclAdder.add(random().nextInt(maxDoc))
+        }
+
+        val req = reqBuilder.build()
+        val excl = exclBuilder.build()
+
+        val reqBulkScorer = object : BulkScorer() {
+            private val iterator = req.iterator()
+
+            override fun score(
+                collector: LeafCollector,
+                acceptDocs: Bits?,
+                min: Int,
+                max: Int
+            ): Int {
+                var doc = iterator.docID()
+                if (iterator.docID() < min) {
+                    doc = iterator.advance(min)
+                }
+                while (doc < max) {
+                    if (acceptDocs == null || acceptDocs.get(doc)) {
+                        collector.collect(doc)
+                    }
+                    doc = iterator.nextDoc()
+                }
+                return doc
+            }
+
+            override fun cost(): Long {
+                return iterator.cost()
+            }
+        }
+
+        val reqExcl = if (twoPhase) {
+            ReqExclBulkScorer(reqBulkScorer, RandomTwoPhaseView(random(), excl.iterator()))
+        } else {
+            ReqExclBulkScorer(reqBulkScorer, excl.iterator())
+        }
+        val actualMatches = FixedBitSet(maxDoc)
+        if (random().nextBoolean()) {
+            reqExcl.score(object : LeafCollector {
+                override var scorer: Scorable? = null
+                override fun collect(doc: Int) {
+                    actualMatches.set(doc)
+                }
+            }, null, 0, DocIdSetIterator.NO_MORE_DOCS)
+        } else {
+            var next = 0
+            while (next < maxDoc) {
+                val min = next
+                val max = min + random().nextInt(10)
+                next = reqExcl.score(object : LeafCollector {
+                    override var scorer: Scorable? = null
+                    override fun collect(doc: Int) {
+                        actualMatches.set(doc)
+                    }
+                }, null, min, max)
+                assertTrue(next >= max)
+            }
+        }
+
+        val expectedMatches = FixedBitSet(maxDoc)
+        expectedMatches.or(req.iterator())
+        val excludedSet = FixedBitSet(maxDoc)
+        excludedSet.or(excl.iterator())
+        expectedMatches.andNot(excludedSet)
+
+        assertContentEquals(expectedMatches.bits, actualMatches.bits)
+    }
+}
+

--- a/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/search/RandomApproximationQuery.kt
+++ b/test-framework/src/commonMain/kotlin/org/gnit/lucenekmp/tests/search/RandomApproximationQuery.kt
@@ -1,0 +1,152 @@
+package org.gnit.lucenekmp.tests.search
+
+import okio.IOException
+import org.gnit.lucenekmp.index.LeafReaderContext
+import org.gnit.lucenekmp.search.*
+import org.gnit.lucenekmp.tests.util.RandomNumbers
+import kotlin.random.Random
+
+/** A [Query] that adds random approximations to its scorers. */
+class RandomApproximationQuery(private val query: Query, private val random: Random) : Query() {
+
+    override fun rewrite(indexSearcher: IndexSearcher): Query {
+        val rewritten = query.rewrite(indexSearcher)
+        return if (rewritten !== query) {
+            RandomApproximationQuery(rewritten, random)
+        } else {
+            super.rewrite(indexSearcher)
+        }
+    }
+
+    override fun visit(visitor: QueryVisitor) {
+        query.visit(visitor)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return sameClassAs(other) && query == (other as RandomApproximationQuery).query
+    }
+
+    override fun hashCode(): Int {
+        return 31 * classHash() + query.hashCode()
+    }
+
+    override fun toString(field: String?): String {
+        return query.toString(field)
+    }
+
+    override fun createWeight(searcher: IndexSearcher, scoreMode: ScoreMode, boost: Float): Weight {
+        val weight = query.createWeight(searcher, scoreMode, boost)
+        return RandomApproximationWeight(weight, Random(random.nextLong()))
+    }
+
+    private class RandomApproximationWeight(weight: Weight, private val random: Random) :
+        FilterWeight(weight) {
+        @Throws(IOException::class)
+        override fun scorerSupplier(context: LeafReaderContext): ScorerSupplier? {
+            val scorerSupplier = `in`.scorerSupplier(context) ?: return null
+            val subScorer = scorerSupplier.get(Long.MAX_VALUE)
+            val scorer = RandomApproximationScorer(subScorer, Random(random.nextLong()))
+            return Weight.DefaultScorerSupplier(scorer)
+        }
+    }
+
+    private class RandomApproximationScorer(
+        private val scorer: Scorer,
+        random: Random
+    ) : Scorer() {
+        private val twoPhaseView = RandomTwoPhaseView(random, scorer.iterator())
+
+        override fun twoPhaseIterator(): TwoPhaseIterator? {
+            return twoPhaseView
+        }
+
+        @Throws(IOException::class)
+        override fun score(): Float {
+            return scorer.score()
+        }
+
+        @Throws(IOException::class)
+        override fun advanceShallow(target: Int): Int {
+            var t = target
+            if (scorer.docID() > t && twoPhaseView.approximation.docID() != scorer.docID()) {
+                // The random approximation can return doc ids that are not present in the underlying
+                // scorer. These additional doc ids are always *before* the next matching doc so we
+                // cannot use them to shallow advance the main scorer which is already ahead.
+                t = scorer.docID()
+            }
+            return scorer.advanceShallow(t)
+        }
+
+        @Throws(IOException::class)
+        override fun getMaxScore(upTo: Int): Float {
+            return scorer.getMaxScore(upTo)
+        }
+
+        override fun docID(): Int {
+            return twoPhaseView.approximation.docID()
+        }
+
+        override fun iterator(): DocIdSetIterator {
+            return TwoPhaseIterator.asDocIdSetIterator(twoPhaseView)
+        }
+    }
+
+    /**
+     * A wrapper around a [DocIdSetIterator] that matches the same documents, but introduces
+     * false positives that need to be verified via [TwoPhaseIterator.matches].
+     */
+    class RandomTwoPhaseView(random: Random, private val disi: DocIdSetIterator) :
+        TwoPhaseIterator(RandomApproximation(random, disi)) {
+        private var lastDoc = -1
+        private val randomMatchCost: Float = random.nextFloat() * 200f
+
+        @Throws(IOException::class)
+        override fun matches(): Boolean {
+            val doc = approximation.docID()
+            require(!(doc == -1 || doc == DocIdSetIterator.NO_MORE_DOCS)) {
+                "matches() should not be called on doc ID $doc"
+            }
+            require(lastDoc != doc) { "matches() has been called twice on doc ID $doc" }
+            lastDoc = doc
+            return doc == disi.docID()
+        }
+
+        override fun matchCost(): Float {
+            return randomMatchCost
+        }
+    }
+
+    private class RandomApproximation(
+        private val random: Random,
+        private val disi: DocIdSetIterator
+    ) : DocIdSetIterator() {
+        private var doc = -1
+
+        override fun docID(): Int {
+            return doc
+        }
+
+        @Throws(IOException::class)
+        override fun nextDoc(): Int {
+            return advance(doc + 1)
+        }
+
+        @Throws(IOException::class)
+        override fun advance(target: Int): Int {
+            if (disi.docID() < target) {
+                disi.advance(target)
+            }
+            doc = if (disi.docID() == NO_MORE_DOCS) {
+                NO_MORE_DOCS
+            } else {
+                RandomNumbers.randomIntBetween(random, target, disi.docID())
+            }
+            return doc
+        }
+
+        override fun cost(): Long {
+            return disi.cost()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FilterWeight and RandomApproximationQuery test utility
- port TestReqExclBulkScorer to Kotlin common tests

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew compileTestKotlinJvm`
- `./gradlew compileKotlinLinuxX64`
- `./gradlew compileTestKotlinLinuxX64`
- `./gradlew core:jvmTest --tests "org.gnit.lucenekmp.search.TestReqExclBulkScorer"`
- `./gradlew jvmTest`
- `./gradlew allTests` *(fails: Failed to find Build Tools revision 35.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc20578c832bb5a316fa769e79ad