### PR TITLE
fix: don't modify log level when env is not present

### DIFF
--- a/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/LoggingConfig.kt
+++ b/core/src/commonMain/kotlin/org/gnit/lucenekmp/util/LoggingConfig.kt
@@ -18,21 +18,27 @@ private fun configureLogging(level: Level) {
     luceneLoggingConfigured = true
 }
 
-private fun parseConfiguredLogLevel(): Level {
-    return when (EnvVar[LOG_LEVEL_ENV_VAR]?.uppercase()) {
+private fun parseConfiguredLogLevel(configuredLogLevel: String?): Level? {
+    return when (configuredLogLevel?.uppercase()) {
         "TRACE" -> Level.TRACE
         "DEBUG" -> Level.DEBUG
         "INFO" -> Level.INFO
         "WARN" -> Level.WARN
         "ERROR" -> Level.ERROR
-        else -> Level.OFF
+        "OFF" -> Level.OFF
+        else -> null
     }
+}
+
+internal fun configureProductionLogging(configuredLogLevel: String?) {
+    parseConfiguredLogLevel(configuredLogLevel)?.let(::configureLogging)
 }
 
 @PublishedApi
 internal fun ensureProductionLoggingConfigured() {
     if (!luceneLoggingConfigured) {
-        configureLogging(parseConfiguredLogLevel())
+        luceneLoggingConfigured = true
+        configureProductionLogging(EnvVar[LOG_LEVEL_ENV_VAR])
     }
 }
 

--- a/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/LoggingConfigTest.kt
+++ b/core/src/commonTest/kotlin/org/gnit/lucenekmp/util/LoggingConfigTest.kt
@@ -1,0 +1,32 @@
+package org.gnit.lucenekmp.util
+
+import io.github.oshai.kotlinlogging.KotlinLoggingConfiguration
+import io.github.oshai.kotlinlogging.Level
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class LoggingConfigTest {
+    @Test
+    fun missingProductionLogLevelPreservesHostConfiguration() {
+        val previousLogStartupMessage = KotlinLoggingConfiguration.logStartupMessage
+        val previousLoggerFactory = KotlinLoggingConfiguration.loggerFactory
+        val previousLogLevel = KotlinLoggingConfiguration.direct.logLevel
+
+        try {
+            KotlinLoggingConfiguration.logStartupMessage = true
+            KotlinLoggingConfiguration.direct.logLevel = Level.WARN
+
+            configureProductionLogging(null)
+
+            assertTrue(KotlinLoggingConfiguration.logStartupMessage)
+            assertSame(previousLoggerFactory, KotlinLoggingConfiguration.loggerFactory)
+            assertEquals(Level.WARN, KotlinLoggingConfiguration.direct.logLevel)
+        } finally {
+            KotlinLoggingConfiguration.logStartupMessage = previousLogStartupMessage
+            KotlinLoggingConfiguration.loggerFactory = previousLoggerFactory
+            KotlinLoggingConfiguration.direct.logLevel = previousLogLevel
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve the host `kotlin-logging` configuration when `LUCENEKMP_LOG_LEVEL` is unset or invalid.
- Continue applying supported explicit Lucene log levels, including `OFF`.
- Add corresponding test.

## Motivation

I included this library and found my logging is gone. It's unreasonable.